### PR TITLE
gitattributes: make GH color .elpi files as Prolog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.elpi linguist-language=prolog


### PR DESCRIPTION
GH does not recognize elpi file, but Prolog is close enough.