### PR TITLE
Optimize constants in reified syntax trees

### DIFF
--- a/theories/quote.elpi
+++ b/theories/quote.elpi
@@ -101,17 +101,18 @@ ring->field _ none.
 % - [OutM] and [Out] are reified terms of [Input], and
 % - [VarMap] is a variable map.
 pred quote.nat i:term, i:term, o:term, o:term, o:list term.
-quote.nat _ {{ lib:num.nat.O }} {{ NatX lib:num.nat.O }} Out _ :- !,
+quote.nat _ {{ lib:num.nat.O }} {{ NatC lib:num.N.N0 }} Out _ :- !,
   quote.expr.constant { z-constant 0 } Out.
 quote.nat Ring {{ lib:num.nat.S lp:In }} OutM Out VarMap :- !,
-  quote.nat Ring { quote.count-succ In N } OutM2 Out2 VarMap, !,
-  N' is N + 1, !,
-  int->nat N' OutM1, !,
-  z-constant N' Out1, !,
-  if (In = {{ lib:num.nat.O }})
-     (OutM = {{ NatX lp:OutM1 }}, quote.expr.constant Out1 Out)
-     (OutM = {{ NatAdd (NatX lp:OutM1) lp:OutM2 }},
-      quote.expr.add { quote.expr.constant Out1 } Out2 Out).
+  quote.count-succ In N In2, !,
+  positive-constant {calc (N + 1)} Out1, !,
+  if (In2 = {{ lib:num.nat.O }})
+     (OutM = {{ NatC (lib:num.N.Npos lp:Out1) }},
+      quote.expr.constant {{ lib:num.Z.Zpos lp:Out1 }} Out)
+     (quote.nat Ring In2 OutM2 Out2 VarMap, !,
+      OutM = {{ NatAdd (NatC (lib:num.N.Npos lp:Out1)) lp:OutM2 }},
+      quote.expr.add
+        {quote.expr.constant {{ lib:num.Z.Zpos lp:Out1 }} } Out2 Out).
 quote.nat Ring {{ addn lp:In1 lp:In2 }}
                {{ NatAdd lp:OutM1 lp:OutM2 }} Out VarMap :- !,
   quote.nat Ring In1 OutM1 Out1 VarMap, !,
@@ -123,16 +124,18 @@ quote.nat Ring {{ muln lp:In1 lp:In2 }}
   quote.nat Ring In2 OutM2 Out2 VarMap, !,
   quote.expr.mul Out1 Out2 Out.
 quote.nat Ring {{ expn lp:In1 lp:In2 }}
-               {{ NatExp lp:OutM1 lp:In2 }} Out VarMap :-
-  nat->int { coq.reduction.vm.norm In2 {{ nat }} } Exp, !,
+               {{ NatExp lp:OutM1 lp:Out2 }} Out VarMap :-
+  coq.reduction.vm.norm {{ N.of_nat lp:In2 }} {{ N }} Out2,
+  n-constant _ Out2,
+  !,
   quote.nat Ring In1 OutM1 Out1 VarMap, !,
-  quote.expr.exp Out1 { n-constant Exp } Out.
+  quote.expr.exp Out1 Out2 Out.
 % For now, we normalize some specific form of terms of type nat.
-quote.nat _ {{ Nat.of_num_uint lp:In' }} {{ NatX lp:In }} Out _ :-
-  In = {{ Nat.of_num_uint lp:In' }},
-  nat->int { coq.reduction.vm.norm In {{ nat }} } N, !,
-  z-constant N Out',
-  quote.expr.constant Out' Out.
+quote.nat _ {{ Nat.of_num_uint lp:In }} {{ NatC lp:OutM }} Out _ :-
+  nat->int { coq.reduction.vm.norm {{ Nat.of_num_uint lp:In }} {{ nat }} } N,
+  !,
+  n-constant N OutM,
+  quote.expr.constant { z-constant N } Out.
 quote.nat Ring In {{ NatX lp:In }} Out VarMap :- !,
   Zmodule = {{ GRing.Ring.zmodType lp:Ring }},
   mem VarMap {{ @GRing.natmul lp:Zmodule (@GRing.one lp:Ring) lp:In }} N, !,
@@ -156,51 +159,50 @@ pred quote.zmod i:term, i:term, i:(term -> term), i:term, i:term,
 % 0%R
 quote.zmod SrcZmodule _ _ _ {{ @GRing.zero lp:SrcZmodule' }}
            {{ @Zmod0 lp:SrcZmodule }} Out _ :-
-  quote.expr.zero Out,
   coq.unify-eq {{ @GRing.zero lp:SrcZmodule }}
-               {{ @GRing.zero lp:SrcZmodule' }} ok,
-  !.
+               {{ @GRing.zero lp:SrcZmodule' }} ok, !,
+  quote.expr.zero Out.
 % -%R
 quote.zmod SrcZmodule TgtRing MorphFun Morph
            {{ @GRing.opp lp:SrcZmodule' lp:In1 }}
            {{ @ZmodOpp lp:SrcZmodule lp:OutM1 }} Out VarMap :-
-  quote.expr.opp Out1 Out,
   coq.unify-eq {{ @GRing.opp lp:SrcZmodule }}
                {{ @GRing.opp lp:SrcZmodule' }} ok,
   !,
-  quote.zmod SrcZmodule TgtRing MorphFun Morph In1 OutM1 Out1 VarMap.
+  quote.zmod SrcZmodule TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+  quote.expr.opp Out1 Out.
 % +%R
 quote.zmod SrcZmodule TgtRing MorphFun Morph
            {{ @GRing.add lp:SrcZmodule' lp:In1 lp:In2 }}
            {{ @ZmodAdd lp:SrcZmodule lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.add Out1 Out2 Out,
   coq.unify-eq {{ @GRing.add lp:SrcZmodule }}
                {{ @GRing.add lp:SrcZmodule' }} ok,
   !,
   quote.zmod SrcZmodule TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  quote.zmod SrcZmodule TgtRing MorphFun Morph In2 OutM2 Out2 VarMap.
+  quote.zmod SrcZmodule TgtRing MorphFun Morph In2 OutM2 Out2 VarMap, !,
+  quote.expr.add Out1 Out2 Out.
 % (_ *+ _)%R
 quote.zmod SrcZmodule TgtRing MorphFun Morph
            {{ @GRing.natmul lp:SrcZmodule' lp:In1 lp:In2 }}
            {{ @ZmodMuln lp:SrcZmodule lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.mul Out1 Out2 Out,
   coq.unify-eq SrcZmodule SrcZmodule' ok,
   !,
   quote.zmod SrcZmodule TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  quote.nat TgtRing In2 OutM2 Out2 VarMap.
+  quote.nat TgtRing In2 OutM2 Out2 VarMap, !,
+  quote.expr.mul Out1 Out2 Out.
 % (_ *~ _)%R
 quote.zmod SrcZmodule TgtRing MorphFun Morph
            {{ @intmul lp:SrcZmodule' lp:In1 lp:In2 }}
            {{ @ZmodMulz lp:SrcZmodule lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.mul Out1 Out2 Out,
   coq.unify-eq SrcZmodule SrcZmodule' ok,
-  TgtZmodule = {{ GRing.Ring.zmodType lp:TgtRing }},
   !,
   quote.zmod SrcZmodule TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
   quote.ring
     {{ int_Ring }} none TgtRing
-    (n\ {{ @intmul lp:TgtZmodule (@GRing.one lp:TgtRing) lp:n }})
-    {{ @intmul1_rmorphism lp:TgtRing }} In2 OutM2 Out2 VarMap.
+    (n\ {{ @intmul (GRing.Ring.zmodType lp:TgtRing)
+                   (@GRing.one lp:TgtRing) lp:n }})
+    {{ @intmul1_rmorphism lp:TgtRing }} In2 OutM2 Out2 VarMap, !,
+  quote.expr.mul Out1 Out2 Out.
 % additive functions
 quote.zmod SrcZmodule TgtRing MorphFun Morph In
            {{ @ZmodMorph lp:NewSrcZmodule lp:SrcZmodule lp:NewMorph lp:OutM }}
@@ -237,135 +239,131 @@ pred quote.ring i:term, i:option term, i:term, i:(term -> term), i:term,
 % 0%R
 quote.ring SrcRing _ _ _ _ {{ @GRing.zero lp:SrcZmodule }}
            {{ @Ring0 lp:SrcRing }} Out _ :-
-  quote.expr.zero Out,
   coq.unify-eq {{ @GRing.zero lp:SrcZmodule }}
-               {{ @GRing.zero (GRing.Ring.zmodType lp:SrcRing) }} ok,
-  !.
+               {{ @GRing.zero (GRing.Ring.zmodType lp:SrcRing) }} ok, !,
+  quote.expr.zero Out.
 % -%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
            {{ @GRing.opp lp:SrcZmodule lp:In1 }}
            {{ @RingOpp lp:SrcRing lp:OutM1 }} Out VarMap :-
-  quote.expr.opp Out1 Out,
   coq.unify-eq {{ @GRing.opp lp:SrcZmodule }}
                {{ @GRing.opp (GRing.Ring.zmodType lp:SrcRing) }} ok,
   !,
-  quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap.
+  quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+  quote.expr.opp Out1 Out.
 % Z.opp
 quote.ring SrcRing none TgtRing MorphFun Morph
            {{ Z.opp lp:In1 }} {{ @RingZOpp lp:OutM1 }} Out VarMap :-
-  quote.expr.opp Out1 Out,
   coq.unify-eq {{ ZInstances.Z_ringType }} SrcRing ok,
   !,
-  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap.
+  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+  quote.expr.opp Out1 Out.
 % +%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
            {{ @GRing.add lp:SrcZmodule lp:In1 lp:In2 }}
            {{ @RingAdd lp:SrcRing lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.add Out1 Out2 Out,
   coq.unify-eq {{ @GRing.add lp:SrcZmodule }}
                {{ @GRing.add (GRing.Ring.zmodType lp:SrcRing) }} ok,
   !,
   quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  quote.ring SrcRing SrcField TgtRing MorphFun Morph In2 OutM2 Out2 VarMap.
+  quote.ring SrcRing SrcField TgtRing MorphFun Morph In2 OutM2 Out2 VarMap, !,
+  quote.expr.add Out1 Out2 Out.
 % Z.add
 quote.ring SrcRing none TgtRing MorphFun Morph
            {{ Z.add lp:In1 lp:In2 }} {{ @RingZAdd lp:OutM1 lp:OutM2 }}
            Out VarMap :-
-  quote.expr.add Out1 Out2 Out,
   coq.unify-eq {{ ZInstances.Z_ringType }} SrcRing ok,
   !,
-  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap,
-  quote.ring SrcRing none TgtRing MorphFun Morph In2 OutM2 Out2 VarMap.
+  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+  quote.ring SrcRing none TgtRing MorphFun Morph In2 OutM2 Out2 VarMap, !,
+  quote.expr.add Out1 Out2 Out.
 % Z.sub
 quote.ring SrcRing none TgtRing MorphFun Morph
            {{ Z.sub lp:In1 lp:In2 }} {{ @RingZSub lp:OutM1 lp:OutM2 }}
            Out VarMap :-
-  quote.expr.add Out1 { quote.expr.opp Out2 } Out,
   coq.unify-eq {{ ZInstances.Z_ringType }} SrcRing ok,
   !,
-  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap,
-  quote.ring SrcRing none TgtRing MorphFun Morph In2 OutM2 Out2 VarMap.
+  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+  quote.ring SrcRing none TgtRing MorphFun Morph In2 OutM2 Out2 VarMap, !,
+  quote.expr.add Out1 { quote.expr.opp Out2 } Out.
 % (_ *+ _)%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
            {{ @GRing.natmul lp:SrcZmodule lp:In1 lp:In2 }}
            {{ @RingMuln lp:SrcRing lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.mul Out1 Out2 Out,
   coq.unify-eq SrcZmodule {{ @GRing.Ring.zmodType lp:SrcRing }} ok,
   !,
   quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  quote.nat TgtRing In2 OutM2 Out2 VarMap.
+  quote.nat TgtRing In2 OutM2 Out2 VarMap, !,
+  quote.expr.mul Out1 Out2 Out.
 % (_ *~ _)%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
            {{ @intmul lp:SrcZmodule lp:In1 lp:In2 }}
            {{ @RingMulz lp:SrcRing lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.mul Out1 Out2 Out,
   coq.unify-eq SrcZmodule {{ @GRing.Ring.zmodType lp:SrcRing }} ok,
-  TgtZmodule = {{ GRing.Ring.zmodType lp:TgtRing }},
   !,
   quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
   quote.ring
     {{ int_Ring }} none TgtRing
-    (n\ {{ @intmul lp:TgtZmodule (@GRing.one lp:TgtRing) lp:n }})
-    {{ @intmul1_rmorphism lp:TgtRing }} In2 OutM2 Out2 VarMap.
+    (n\ {{ @intmul (GRing.Ring.zmodType lp:TgtRing)
+                   (@GRing.one lp:TgtRing) lp:n }})
+    {{ @intmul1_rmorphism lp:TgtRing }} In2 OutM2 Out2 VarMap, !,
+  quote.expr.mul Out1 Out2 Out.
 % 1%R
 quote.ring SrcRing _ _ _ _ {{ @GRing.one lp:SrcRing' }}
            {{ @Ring1 lp:SrcRing }} Out _ :-
-  quote.expr.one Out,
   coq.unify-eq {{ @GRing.one lp:SrcRing' }} {{ @GRing.one lp:SrcRing }} ok,
-  !.
+  !,
+  quote.expr.one Out.
 % *%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
            {{ @GRing.mul lp:SrcRing' lp:In1 lp:In2 }}
            {{ @RingMul lp:SrcRing lp:OutM1 lp:OutM2 }} Out VarMap :-
-  quote.expr.mul Out1 Out2 Out,
   coq.unify-eq {{ @GRing.mul lp:SrcRing' }} {{ @GRing.mul lp:SrcRing }} ok,
   !,
   quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  quote.ring SrcRing SrcField TgtRing MorphFun Morph In2 OutM2 Out2 VarMap.
+  quote.ring SrcRing SrcField TgtRing MorphFun Morph In2 OutM2 Out2 VarMap, !,
+  quote.expr.mul Out1 Out2 Out.
 % Z.mul
 quote.ring SrcRing none TgtRing MorphFun Morph
            {{ Z.mul lp:In1 lp:In2 }} {{ @RingZMul lp:OutM1 lp:OutM2 }}
            Out VarMap :-
-  quote.expr.mul Out1 Out2 Out,
   coq.unify-eq {{ ZInstances.Z_ringType }} SrcRing ok,
   !,
-  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap,
-  quote.ring SrcRing none TgtRing MorphFun Morph In2 OutM2 Out2 VarMap.
+  quote.ring SrcRing none TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+  quote.ring SrcRing none TgtRing MorphFun Morph In2 OutM2 Out2 VarMap, !,
+  quote.expr.mul Out1 Out2 Out.
 % (_ ^+ _)%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
            {{ @GRing.exp lp:SrcRing' lp:In1 lp:In2 }}
-           {{ @RingExpn lp:SrcRing lp:OutM1 lp:In2 }} Out VarMap :-
-  quote.expr.exp Out1 Out2 Out,
+           {{ @RingExpn lp:SrcRing lp:OutM1 lp:Out2 }} Out VarMap :-
   coq.unify-eq SrcRing' SrcRing ok,
-  nat->int { coq.reduction.vm.norm In2 {{ nat }} } Exp,
+  n-constant { nat->int { coq.reduction.vm.norm In2 {{ nat }} } } Out2,
   !,
   quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  n-constant Exp Out2.
-% (_ ^ Posz _)%R
+  quote.expr.exp Out1 Out2 Out.
+% (_ ^ _)%R
 quote.ring SrcRing SrcField TgtRing MorphFun Morph
-           {{ @exprz lp:SrcUnitRing lp:In1 lp:In2 }}
-           {{ @RingExpPosz lp:SrcUnitRing lp:OutM1 lp:In2' }} Out VarMap :-
-  quote.expr.exp Out1 Out2 Out,
-  coq.unify-eq {{ GRing.UnitRing.ringType lp:SrcUnitRing }} SrcRing ok,
-  coq.reduction.vm.norm In2 {{ int }} {{ Posz lp:In2' }},
-  nat->int In2' Exp,
-  !,
-  quote.ring SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
-  n-constant Exp Out2.
-% (_ ^ Negz _)%R
-quote.ring SrcRing (some SrcField) TgtRing MorphFun Morph
-           {{ @exprz lp:SrcUnitRing lp:In1 lp:In2 }}
-           {{ @RingExpNegz lp:SrcField lp:OutM1 lp:In2' }}
-           {{ @FEinv Z (@FEpow Z lp:Out1 lp:Out2) }} VarMap :-
-  field-mode,
-  coq.unify-eq {{ lp:SrcUnitRing }}
-               {{ GRing.Field.unitRingType lp:SrcField }} ok,
-  coq.reduction.vm.norm In2 {{ int }} {{ Negz lp:In2' }},
-  nat->int In2' Exp,
-  !,
-  quote.ring SrcRing (some SrcField) TgtRing MorphFun Morph
-             In1 OutM1 Out1 VarMap, !,
-  n-constant {calc (Exp + 1)} Out2.
+           {{ @exprz lp:SrcUnitRing lp:In1 lp:In2 }} OutM Out VarMap :-
+  z-constant Exp { coq.reduction.vm.norm {{ Z_of_int lp:In2 }} {{ Z }} },
+  if (Exp >= 0)
+     (CONT =
+       (coq.unify-eq {{ GRing.UnitRing.ringType lp:SrcUnitRing }} SrcRing ok, !,
+        quote.ring
+          SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+        n-constant Exp Out2, !,
+        OutM = {{ @RingExpPosz lp:SrcUnitRing lp:OutM1 lp:Out2 }}, !,
+        quote.expr.exp Out1 Out2 Out))
+     (CONT =
+       (field-mode,
+        SrcField = some SrcField',
+        coq.unify-eq {{ lp:SrcUnitRing }}
+                     {{ GRing.Field.unitRingType lp:SrcField' }} ok, !,
+        quote.ring
+          SrcRing SrcField TgtRing MorphFun Morph In1 OutM1 Out1 VarMap, !,
+        n-constant { calc (~ (Exp + 1)) } Out2, !,
+        OutM = {{ @RingExpNegz lp:SrcField' lp:OutM1 lp:Out2 }}, !,
+        Out = {{ @FEinv Z (@FEpow Z lp:Out1 lp:Out2) }})),
+  CONT.
 % Z.pow
 quote.ring SrcRing none TgtRing MorphFun Morph
            {{ Z.pow lp:In1 lp:In2 }} {{ @RingZExp lp:OutM1 lp:In2' }}
@@ -398,15 +396,15 @@ quote.ring SrcRing _ TgtRing _ _
 % Negz
 quote.ring SrcRing _ TgtRing _ _ {{ Negz lp:In }}
            {{ @RingNegz lp:OutM1 }} Out VarMap :-
-  quote.expr.opp { quote.expr.add { quote.expr.one } Out1 } Out,
   coq.unify-eq {{ int_Ring }} SrcRing ok,
   !,
-  quote.nat TgtRing In OutM1 Out1 VarMap.
+  quote.nat TgtRing In OutM1 Out1 VarMap, !,
+  quote.expr.opp { quote.expr.add { quote.expr.one } Out1 } Out.
 % Z constants
 quote.ring SrcRing _ _ _ _ In {{ @RingZC lp:In }} Out _ :-
-  quote.expr.constant In Out,
   coq.unify-eq {{ ZInstances.Z_ringType }} SrcRing ok,
-  z-constant _ In, !.
+  z-constant _ In, !,
+  quote.expr.constant In Out.
 % morphisms
 quote.ring SrcRing _ TgtRing MorphFun Morph In
            {{ @RingMorph lp:NewSrcRing lp:SrcRing lp:NewMorph lp:OutM }}
@@ -439,9 +437,8 @@ quote.ring SrcRing _ TgtRing MorphFun Morph In
   quote.zmod NewSrcZmodule TgtRing
              (x\ MorphFun (NewMorphFun x)) CompMorph In1 OutM Out VarMap.
 % variables
-quote.ring SrcRing _ _ MorphFun _ In {{ @RingX lp:SrcRing lp:In }} Out VarMap :-
-  mem VarMap (MorphFun In) N,
-  quote.expr.variable { positive-constant {calc (N + 1)} } Out,
-  !.
+quote.ring SrcRing _ _ MorphFun _ In {{ @RingX lp:SrcRing lp:In }} Out VarMap :- !,
+  mem VarMap (MorphFun In) N, !,
+  quote.expr.variable { positive-constant {calc (N + 1)} } Out.
 quote.ring _ _ _ _ _ In _ _ _ :- coq.error "Unknown" {coq.term->string In}.
 % TODO: converse ring

--- a/theories/ring.v
+++ b/theories/ring.v
@@ -16,15 +16,66 @@ Module Import Internals.
 
 Implicit Types (V : zmodType) (R : ringType) (F : fieldType).
 
+(* In reified syntax trees, constants must be represented by binary integers  *)
+(* `N` and `Z`. For the fine-grained control of conversion, we provide opaque *)
+(* and transparent (immediately expanding) versions of `N -> nat` and         *)
+(* `Z -> int` conversions.                                                    *)
+
+Module Type NatOfNSig.
+Parameter nat_of_N_opaque : N -> nat.
+Axiom nat_of_N_opaqueE : nat_of_N_opaque = nat_of_N.
+End NatOfNSig.
+
+Module Import NatOfN : NatOfNSig.
+Definition nat_of_N_opaque := nat_of_N.
+Definition nat_of_N_opaqueE := erefl nat_of_N.
+End NatOfN.
+
+Module Type IntOfZSig.
+Parameter int_of_Z_opaque : Z -> int.
+Axiom int_of_Z_opaqueE : int_of_Z_opaque = int_of_Z.
+End IntOfZSig.
+
+Module Import IntOfZ : IntOfZSig.
+Definition int_of_Z_opaque := int_of_Z.
+Definition int_of_Z_opaqueE := erefl int_of_Z.
+End IntOfZ.
+
+Definition addn_expand := Eval compute in addn.
+
+Fixpoint nat_of_pos_rec_expand (p : positive) (a : nat) : nat :=
+  match p with
+  | p0~1 => addn_expand a (nat_of_pos_rec_expand p0 (addn_expand a a))
+  | p0~0 => nat_of_pos_rec_expand p0 (addn_expand a a)
+  | 1 => a
+  end%positive.
+
+Definition nat_of_pos_expand (p : positive) : nat := nat_of_pos_rec_expand p 1.
+
+Definition nat_of_N_expand (n : N) : nat :=
+  if n is N.pos p then nat_of_pos_expand p else 0%N.
+
+Definition int_of_Z_expand (n : Z) : int :=
+  match n with
+    | Z0 => Posz 0
+    | Zpos p => Posz (nat_of_pos_expand p)
+    | Zneg p => Negz (nat_of_pos_expand p).-1
+  end.
+
+Lemma nat_of_N_expandE : nat_of_N_expand = nat_of_N. Proof. by []. Qed.
+Lemma int_of_Z_expandE : int_of_Z_expand = int_of_Z. Proof. by []. Qed.
+
 (* Normalizing ring and field expressions to the Horner form by reflection    *)
+
+Definition R_of_Z (R : ringType) (n : Z) : R := (int_of_Z_opaque n)%:~R.
 
 Lemma RE R : @ring_eq_ext R +%R *%R -%R eq.
 Proof. by split; do! move=> ? _ <-. Qed.
 
 Lemma RZ R : ring_morph 0 1 +%R *%R (fun x y : R => x - y) -%R eq
-                        0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb
-                        (fun n => (int_of_Z n)%:~R).
+                        0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb (R_of_Z R).
 Proof.
+rewrite /R_of_Z int_of_Z_opaqueE.
 split=> //= [x y | x y | x y | x | x y /Z.eqb_eq -> //].
 - by rewrite !rmorphD.
 - by rewrite !rmorphB.
@@ -32,10 +83,11 @@ split=> //= [x y | x y | x y | x | x y /Z.eqb_eq -> //].
 - by rewrite !rmorphN.
 Qed.
 
-Lemma PN R : @power_theory R 1 *%R eq nat nat_of_N (@GRing.exp R).
+Lemma PN R : @power_theory R 1 *%R eq nat nat_of_N_opaque (@GRing.exp R).
 Proof.
-by split=> r [] //=; elim=> //= p <-;
-  rewrite (Pos2Nat.inj_xI, Pos2Nat.inj_xO) ?exprS -exprD addnn -mul2n.
+rewrite nat_of_N_opaqueE; split => r [] //=; elim=> //= p <-.
+- by rewrite Pos2Nat.inj_xI ?exprS -exprD addnn -mul2n.
+- by rewrite Pos2Nat.inj_xO ?exprS -exprD addnn -mul2n.
 Qed.
 
 Lemma RR (R : comRingType) :
@@ -64,37 +116,42 @@ Definition Fcorrect F :=
 (* Pushing down morphisms in ring and field expressions by reflection         *)
 
 Inductive NatExpr : Type :=
+  | NatC    of N
   | NatX    of nat
   | NatAdd  of NatExpr & NatExpr
   | NatSucc of NatExpr
   | NatMul  of NatExpr & NatExpr
-  | NatExp  of NatExpr & nat.
+  | NatExp  of NatExpr & N.
 
 Fixpoint NatEval (ne : NatExpr) : nat :=
   match ne with
+    | NatC n => nat_of_N_expand n
     | NatX x => x
     | NatAdd e1 e2 => NatEval e1 + NatEval e2
     | NatSucc e => S (NatEval e)
     | NatMul e1 e2 => NatEval e1 * NatEval e2
-    | NatExp e1 n => NatEval e1 ^ n
+    | NatExp e1 n => NatEval e1 ^ nat_of_N_expand n
   end.
 
 Fixpoint NatEval' R (e : NatExpr) : R :=
   match e with
+    | NatC N0 => R_of_Z R Z0
+    | NatC (Npos n) => R_of_Z R (Zpos n)
     | NatX x => x%:~R
     | NatAdd e1 e2 => NatEval' R e1 + NatEval' R e2
     | NatSucc e1 => 1 + NatEval' R e1
     | NatMul e1 e2 => NatEval' R e1 * NatEval' R e2
-    | NatExp e1 n => NatEval' R e1 ^+ n
+    | NatExp e1 n => NatEval' R e1 ^+ nat_of_N_opaque n
   end.
 
 Lemma NatEval_correct R (e : NatExpr) : (NatEval e)%:R = NatEval' R e.
 Proof.
 elim: e => //=.
+- by rewrite /R_of_Z int_of_Z_opaqueE; case.
 - by move=> e1 IHe1 e2 IHe2; rewrite natrD IHe1 IHe2.
 - by move=> e IHe; rewrite mulrS IHe.
 - by move=> e1 IHe1 e2 IHe2; rewrite natrM IHe1 IHe2.
-- by move=> e1 IHe1 e2; rewrite natrX IHe1.
+- by move=> e1 IHe1 e2; rewrite natrX IHe1 nat_of_N_opaqueE.
 Qed.
 
 Inductive RingExpr : ringType -> Type :=
@@ -113,9 +170,9 @@ Inductive RingExpr : ringType -> Type :=
   | RingMul R : RingExpr R -> RingExpr R -> RingExpr R
   | RingZMul : RingExpr [ringType of Z] -> RingExpr [ringType of Z] ->
                RingExpr [ringType of Z]
-  | RingExpn R : RingExpr R -> nat -> RingExpr R
-  | RingExpPosz (R : unitRingType) : RingExpr R -> nat -> RingExpr R
-  | RingExpNegz F : RingExpr F -> nat -> RingExpr F
+  | RingExpn R : RingExpr R -> N -> RingExpr R
+  | RingExpPosz (R : unitRingType) : RingExpr R -> N -> RingExpr R
+  | RingExpNegz F : RingExpr F -> N -> RingExpr F
   | RingZExp : RingExpr [ringType of Z] -> Z -> RingExpr [ringType of Z]
   | RingInv F : RingExpr F -> RingExpr F
   | RingMorph R' R : {rmorphism R' -> R} -> RingExpr R' -> RingExpr R
@@ -149,9 +206,9 @@ Fixpoint RingEval R (e : RingExpr R) : R :=
     | Ring1 _ => 1%R
     | RingMul _ e1 e2 => RingEval e1 * RingEval e2
     | RingZMul e1 e2 => Z.mul (RingEval e1) (RingEval e2)
-    | RingExpn _ e1 n => RingEval e1 ^+ n
-    | RingExpPosz _ e1 n => RingEval e1 ^ Posz n
-    | RingExpNegz _ e1 n => RingEval e1 ^ Negz n
+    | RingExpn _ e1 n => RingEval e1 ^+ nat_of_N_expand n
+    | RingExpPosz _ e1 n => RingEval e1 ^ Posz (nat_of_N_expand n)
+    | RingExpNegz _ e1 n => RingEval e1 ^ Negz (nat_of_N_expand n)
     | RingZExp e1 n => Z.pow (RingEval e1) n
     | RingInv _ e1 => (RingEval e1) ^-1
     | RingMorph _ _ f e1 => f (RingEval e1)
@@ -186,17 +243,17 @@ Fixpoint RingEval' R R' (f : {rmorphism R -> R'}) (e : RingExpr R) : R' :=
     | Ring1 _ => fun => 1%R
     | RingMul _ e1 e2 => fun f => RingEval' f e1 * RingEval' f e2
     | RingZMul e1 e2 => fun f => RingEval' f e1 * RingEval' f e2
-    | RingExpn _ e1 n => fun f => RingEval' f e1 ^+ n
-    | RingExpPosz _ e1 n => fun f => RingEval' f e1 ^+ n
-    | RingExpNegz _ e1 n => fun f => f (RingEval e1 ^- n.+1)
+    | RingExpn _ e1 n => fun f => RingEval' f e1 ^+ nat_of_N_opaque n
+    | RingExpPosz _ e1 n => fun f => RingEval' f e1 ^+ nat_of_N_opaque n
+    | RingExpNegz _ e1 n => fun f => f (RingEval e1 ^- (nat_of_N_opaque n).+1)
     | RingZExp e1 (Z.neg _) => fun f => 0%Z
-    | RingZExp e1 n => fun f => RingEval' f e1 ^+ Z.to_nat n
+    | RingZExp e1 n => fun f => RingEval' f e1 ^+ nat_of_N_opaque (Z.to_N n)
     | RingInv _ e1 => fun f => f (RingEval e1)^-1
     | RingMorph _ _ g e1 => fun f => RingEval' [rmorphism of f \o g] e1
     | RingMorph' _ _ g e1 => fun f => RZmodEval' [additive of f \o g] e1
     | RingPosz e1 => fun => NatEval' _ e1
     | RingNegz e1 => fun => - (1 + NatEval' _ e1)
-    | RingZC x => fun => (int_of_Z x)%:~R
+    | RingZC x => fun => R_of_Z R' x
   end f
 with RZmodEval' V R (f : {additive V -> R}) (e : ZmodExpr V) : R :=
   match e in ZmodExpr V return {additive V -> R} -> R with
@@ -229,16 +286,18 @@ move: R' f; elim e using (@RingExpr_ind' P P0); rewrite {R e}/P {}/P0 //=.
 - by move=> R R' f; rewrite rmorph1.
 - by move=> R e1 IHe1 e2 IHe2 R' f; rewrite rmorphM IHe1 IHe2.
 - by move=> e1 IHe1 e2 IHe2 R' f; rewrite rmorphM IHe1 IHe2.
-- by move=> R e1 IHe1 e2 R' f; rewrite rmorphX IHe1.
-- by move=> R e1 IHe1 n R' f; rewrite rmorphX IHe1.
-- move=> e1 IHe1 [|n|n] R' f; rewrite ?rmorph0 ?rmorph1 //=.
+- by move=> R e1 IHe1 e2 R' f; rewrite rmorphX IHe1 nat_of_N_opaqueE.
+- by move=> R e1 IHe1 e2 R' f; rewrite rmorphX IHe1 nat_of_N_opaqueE.
+- by rewrite nat_of_N_opaqueE.
+- move=> e1 IHe1 [|n|n] R' f; rewrite ?rmorph0 ?rmorph1 ?nat_of_N_opaqueE //=.
   by rewrite -IHe1 -rmorphX; congr (f _); lia.
 - by move=> R R' g e1 IHe1 R'' f; rewrite -IHe1.
 - by move=> V R g e1 IHe1 R' f; rewrite -IHe1.
 - by move=> e R' f; rewrite -[Posz _]intz rmorph_int [LHS]NatEval_correct.
 - move=> e R' f.
   by rewrite -[Negz _]intz rmorph_int /intmul mulrS NatEval_correct.
-- by move=> x R' f; rewrite -(rmorph_int f); congr (f _); lia.
+- move=> x R' f; rewrite /R_of_Z int_of_Z_opaqueE -(rmorph_int f); congr (f _).
+  lia.
 - by move=> V R f; rewrite raddf0.
 - by move=> V e1 IHe1 R f; rewrite raddfN IHe1.
 - by move=> V e1 IHe1 e2 IHe2 R f; rewrite raddfD IHe1 IHe2.
@@ -266,17 +325,17 @@ Fixpoint FieldEval' R F (f : {rmorphism R -> F}) (e : RingExpr R) : F :=
     | Ring1 _ => fun => 1%R
     | RingMul _ e1 e2 => fun f => FieldEval' f e1 * FieldEval' f e2
     | RingZMul e1 e2 => fun f => FieldEval' f e1 * FieldEval' f e2
-    | RingExpn _ e1 n => fun f => FieldEval' f e1 ^+ n
-    | RingExpPosz _ e1 n => fun f => FieldEval' f e1 ^+ n
-    | RingExpNegz _ e1 n => fun f => (FieldEval' f e1 ^- n.+1)
+    | RingExpn _ e1 n => fun f => FieldEval' f e1 ^+ nat_of_N_opaque n
+    | RingExpPosz _ e1 n => fun f => FieldEval' f e1 ^+ nat_of_N_opaque n
+    | RingExpNegz _ e1 n => fun f => (FieldEval' f e1 ^- (nat_of_N_opaque n).+1)
     | RingZExp e1 (Z.neg _) => fun f => 0%Z
-    | RingZExp e1 n => fun f => FieldEval' f e1 ^+ Z.to_nat n
+    | RingZExp e1 n => fun f => FieldEval' f e1 ^+ nat_of_N_opaque (Z.to_N n)
     | RingInv _ e1 => fun f => (FieldEval' f e1)^-1
     | RingMorph _ _ g e1 => fun f => FieldEval' [rmorphism of f \o g] e1
     | RingMorph' _ _ g e1 => fun f => FZmodEval' [additive of f \o g] e1
     | RingPosz e1 => fun => NatEval' _ e1
     | RingNegz e1 => fun => - (1 + NatEval' _ e1)
-    | RingZC x => fun => (int_of_Z x)%:~R
+    | RingZC x => fun => R_of_Z F x
   end f
 with FZmodEval' V F (f : {additive V -> F}) (e : ZmodExpr V) : F :=
   match e in ZmodExpr V return {additive V -> F} -> F with
@@ -309,10 +368,10 @@ move: F f; elim e using (@RingExpr_ind' P P0); rewrite {R e}/P {}/P0 //=.
 - by move=> R F f; rewrite rmorph1.
 - by move=> R e1 IHe1 e2 IHe2 F f; rewrite rmorphM IHe1 IHe2.
 - by move=> e1 IHe1 e2 IHe2 F f; rewrite rmorphM IHe1 IHe2.
-- by move=> R e1 IHe1 e2 F f; rewrite rmorphX IHe1.
-- by move=> R e1 IHe1 n R' f; rewrite rmorphX IHe1.
-- by move=> R e1 IHe1 n R' f; rewrite fmorphV rmorphX IHe1.
-- move=> e1 IHe1 [|n|n] F f; rewrite ?rmorph0 ?rmorph1 //=.
+- by move=> R e1 IHe1 e2 F f; rewrite rmorphX IHe1 nat_of_N_opaqueE.
+- by move=> R e1 IHe1 n R' f; rewrite rmorphX IHe1 nat_of_N_opaqueE.
+- by move=> R e1 IHe1 n R' f; rewrite fmorphV rmorphX IHe1 nat_of_N_opaqueE.
+- move=> e1 IHe1 [|n|n] F f; rewrite ?rmorph0 ?rmorph1 ?nat_of_N_opaqueE //=.
   rewrite -IHe1 -rmorphX; congr (f _); lia.
 - by move=> F' e1 IHe1 F f; rewrite fmorphV IHe1.
 - by move=> R R' g e1 IHe1 F f; rewrite -IHe1.
@@ -320,7 +379,8 @@ move: F f; elim e using (@RingExpr_ind' P P0); rewrite {R e}/P {}/P0 //=.
 - by move=> e F f; rewrite -[Posz _]intz rmorph_int [LHS]NatEval_correct.
 - move=> e F f.
   by rewrite -[Negz _]intz rmorph_int /intmul mulrS NatEval_correct.
-- by move=> x F f; rewrite -(rmorph_int f); congr (f _); lia.
+- move=> x F f; rewrite /R_of_Z int_of_Z_opaqueE -(rmorph_int f); congr (f _).
+  lia.
 - by move=> V F f; rewrite raddf0.
 - by move=> V e1 IHe1 F f; rewrite raddfN IHe1.
 - by move=> V e1 IHe1 e2 IHe2 F f; rewrite raddfD IHe1 IHe2.
@@ -365,25 +425,25 @@ Qed.
 End PCond.
 
 Lemma lock_PCond (F : fieldType) (l : seq F) (le : seq (PExpr Z)) :
-  (forall is_true_ andb_ zero one add mul sub opp Feqb R_of_Z exp l',
+  (forall is_true_ andb_ zero one add mul sub opp Feqb R_of_Z_ exp l',
       is_true_ = is_true -> andb_ = andb ->
       zero = 0 -> one = 1 -> add = +%R -> mul = *%R ->
       sub = (fun x y => x - y) -> opp = -%R ->
       Feqb = (fun x y => ~~ (x == y)) ->
-      R_of_Z = (fun x => (int_of_Z x)%:~R) -> exp = @GRing.exp F -> l' = l ->
+      R_of_Z_ = (fun x => (int_of_Z x)%:~R) -> exp = @GRing.exp F -> l' = l ->
       is_true_
-        (PCondb andb_ zero one add mul sub opp Feqb R_of_Z N.to_nat exp l'
+        (PCondb andb_ zero one add mul sub opp Feqb R_of_Z_ N.to_nat exp l'
                 (Fapp (Fcons00 0 1 Z.add Z.mul Z.sub Z.opp Z.eqb
                                (triv_div 0 1 Z.eqb)) le [::]))) ->
-  Field_theory.PCond
-    0 1 +%R *%R (fun x y => x - y) -%R eq
-    (fun n : Z => (int_of_Z n)%:~R) N.to_nat (@GRing.exp F) l le.
+  Field_theory.PCond 0 1 +%R *%R (fun x y => x - y) -%R eq
+                     (R_of_Z F) nat_of_N_opaque (@GRing.exp F) l le.
 Proof.
 move=> H.
 apply: Pcond_simpl_gen;
   [ exact: RE | exact/F2AF/RF/RE | exact: RZ | exact: PN |
     exact/triv_div_th/RZ/Rth_ARth/RR/RE/RE/Eqsth | ].
-move=> _ ->; apply/PCondP/(H is_true); try exact: erefl.
+move=> _ ->; rewrite /R_of_Z int_of_Z_opaqueE nat_of_N_opaqueE.
+apply/PCondP/(H is_true); try exact: erefl.
 by move=> ? ?; apply/(iffP negP); apply/contra_not => /eqP.
 Qed.
 
@@ -398,16 +458,16 @@ Lemma lock_PCond_ (F : numFieldType) (l : seq F) (le : seq (PExpr Z)) :
         (PCondb andb_ zero one add mul sub opp Feqb R_of_Z N.to_nat exp l'
                 (Fapp (Fcons2 0 1 Z.add Z.mul Z.sub Z.opp Z.eqb
                                (triv_div 0 1 Z.eqb)) le [::]))) ->
-  Field_theory.PCond
-    0 1 +%R *%R (fun x y => x - y) -%R eq
-    (fun n : Z => (int_of_Z n)%:~R) N.to_nat (@GRing.exp F) l le.
+  Field_theory.PCond 0 1 +%R *%R (fun x y => x - y) -%R eq
+                     (R_of_Z F) nat_of_N_opaque (@GRing.exp F) l le.
 Proof.
 move=> H.
 apply: Pcond_simpl_complete;
   [ exact: RE | exact/F2AF/RF/RE | exact: RZ | exact: PN |
     exact/triv_div_th/RZ/Rth_ARth/RR/RE/RE/Eqsth | | ].
-- move=> x y /intr_inj; lia.
-- move=> _ ->; apply/PCondP/(H is_true); try exact: erefl.
+- by rewrite /R_of_Z int_of_Z_opaqueE => x y /intr_inj; lia.
+- move=> _ ->; rewrite /R_of_Z int_of_Z_opaqueE nat_of_N_opaqueE.
+  apply/PCondP/(H is_true); try exact: erefl.
   by move=> ? ?; apply/(iffP negP); apply/contra_not => /eqP.
 Qed.
 
@@ -458,7 +518,9 @@ Ltac field_reflection F VarMap Lpe RE1 RE2 PE1 PE2 LpeProofs :=
 
 End Internals.
 
-Strategy expand [RingEval RingEval' FieldEval' PEeval FEeval].
+Strategy expand
+         [addn_expand nat_of_pos_rec_expand nat_of_pos_expand nat_of_N_expand
+          int_of_Z_expand RingEval RingEval' FieldEval' PEeval FEeval].
 
 Register Coq.Init.Logic.eq       as ring.eq.
 Register Coq.Init.Logic.eq_refl  as ring.erefl.


### PR DESCRIPTION
Integer constants are now represented by binary integers `N` and `Z` in reified syntax trees, including one for pushing down morphisms. To compare them with the goal, these constants expand to `nat` constants immediately (see `nat_of_N_expand`). After the first step of reflection, it becomes opaque to prevent unwanted reductions (see `nat_of_N_opaque`). In generated non-zero conditions of the `field` tactic, it becomes transparent again.