### PR TITLE
Lra

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,22 +17,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
-          - 'mathcomp/mathcomp:1.12.0-coq-8.14'
-          - 'mathcomp/mathcomp:1.13.0-coq-8.13'
-          - 'mathcomp/mathcomp:1.13.0-coq-8.14'
-          - 'mathcomp/mathcomp:1.13.0-coq-8.15'
-          - 'mathcomp/mathcomp:1.14.0-coq-8.13'
-          - 'mathcomp/mathcomp:1.14.0-coq-8.14'
-          - 'mathcomp/mathcomp:1.14.0-coq-8.15'
-          - 'mathcomp/mathcomp:1.15.0-coq-8.13'
-          - 'mathcomp/mathcomp:1.15.0-coq-8.14'
-          - 'mathcomp/mathcomp:1.15.0-coq-8.15'
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
-          - 'mathcomp/mathcomp:1.15.0-coq-dev'
-          - 'mathcomp/mathcomp-dev:coq-8.13'
-          - 'mathcomp/mathcomp-dev:coq-8.14'
-          - 'mathcomp/mathcomp-dev:coq-8.15'
           - 'mathcomp/mathcomp-dev:coq-8.16'
           - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ Make*.coq.conf
 *#
 .lia.cache
 .nia.cache
+examples/.csdp.cache
+examples/.nra.cache
+examples/trace
+theories/.csdp.cache
+theories/.nra.cache
+theories/trace

--- a/Make
+++ b/Make
@@ -1,4 +1,5 @@
 theories/ring.v
+theories/lra.v
 
 -R theories mathcomp.algebra_tactics
 -arg -w -arg -notation-overridden

--- a/Make.test-suite
+++ b/Make.test-suite
@@ -4,6 +4,7 @@ examples/ring_examples_check.v
 examples/ring_examples_no_check.v
 examples/from_sander.v
 examples/zmodule.v
+examples/lra_examples.v
 
 -R examples mathcomp.algebra_tactics.examples
 -arg -w -arg -notation-overridden

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,2 +1,2 @@
 theories/ring.vo : theories/common.elpi theories/ring.elpi theories/field.elpi
-theories/lra.vo : theories/lra.elpi
+theories/lra.vo : theories/lra.elpi theories/compat815.elpi

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,1 +1,2 @@
-theories/ring.vo : $(wildcard theories/*.elpi)
+theories/ring.vo : theories/common.elpi theories/ring.elpi theories/field.elpi
+theories/lra.vo : theories/lra.elpi

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,2 +1,2 @@
 theories/ring.vo : theories/common.elpi theories/ring.elpi theories/field.elpi
-theories/lra.vo : theories/lra.elpi theories/compat815.elpi
+theories/lra.vo : theories/lra.elpi

--- a/README.md
+++ b/README.md
@@ -12,28 +12,29 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 
 
 
-This library provides `ring` and `field` tactics for Mathematical Components,
-that work with any `comRingType` and `fieldType` instances, respectively.
-Their instance resolution is done through canonical structure inference.
-Therefore, they work with abstract rings and do not require `Add Ring` and
-`Add Field` commands. Another key feature of this library is that they
-automatically push down ring morphisms and additive functions to leaves of
-ring/field expressions before normalization to the Horner form.
+This library provides `ring`, `field`, and `lra` tactics for Mathematical
+Components, that work with any `comRingType`, `fieldType`, and
+`realDomainType` or `realFieldType` instances, respectively. Their instance
+resolution is done through canonical structure inference.  Therefore, they
+work with abstract rings and do not require `Add Ring` and `Add Field`
+commands. Another key feature of this library is that they automatically push
+down ring morphisms and additive functions to leaves of ring/field expressions
+before applying the proof procedures.
 
 ## Meta
 
 - Author(s):
   - Kazuhiko Sakaguchi (initial)
 - License: [CeCILL-B Free Software License Agreement](CeCILL-B)
-- Compatible Coq versions: 8.13 or later
+- Compatible Coq versions: 8.16 or later
 - Additional dependencies:
-  - [MathComp](https://math-comp.github.io) ssreflect 1.12 or later
+  - [MathComp](https://math-comp.github.io) ssreflect 1.15 or later
   - [MathComp](https://math-comp.github.io) algebra
   - [Mczify](https://github.com/math-comp/mczify) 1.1.0 or later
-  - [Coq-Elpi](https://github.com/LPCIC/coq-elpi) 1.10.1 or later
+  - [Coq-Elpi](https://github.com/LPCIC/coq-elpi) 1.15.0 or later
 - Coq namespace: `mathcomp.algebra_tactics`
 - Related publication(s):
-  - [Reflexive tactics for algebra, revisited](https://arxiv.org/abs/2202.04330) 
+  - [Reflexive tactics for algebra, revisited](https://drops.dagstuhl.de/opus/volltexte/2022/16738/) doi:[10.4230/LIPIcs.ITP.2022.29](https://doi.org/10.4230/LIPIcs.ITP.2022.29)
 
 ## Building and installation instructions
 

--- a/coq-mathcomp-algebra-tactics.opam
+++ b/coq-mathcomp-algebra-tactics.opam
@@ -12,22 +12,23 @@ license: "CECILL-B"
 
 synopsis: "Ring and field tactics for Mathematical Components"
 description: """
-This library provides `ring` and `field` tactics for Mathematical Components,
-that work with any `comRingType` and `fieldType` instances, respectively.
-Their instance resolution is done through canonical structure inference.
-Therefore, they work with abstract rings and do not require `Add Ring` and
-`Add Field` commands. Another key feature of this library is that they
-automatically push down ring morphisms and additive functions to leaves of
-ring/field expressions before normalization to the Horner form."""
+This library provides `ring`, `field`, and `lra` tactics for Mathematical
+Components, that work with any `comRingType`, `fieldType`, and
+`realDomainType` or `realFieldType` instances, respectively. Their instance
+resolution is done through canonical structure inference.  Therefore, they
+work with abstract rings and do not require `Add Ring` and `Add Field`
+commands. Another key feature of this library is that they automatically push
+down ring morphisms and additive functions to leaves of ring/field expressions
+before applying the proof procedures."""
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.13"}
-  "coq-mathcomp-ssreflect" {>= "1.12"}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "1.15"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-zify" {>= "1.1.0"}
-  "coq-elpi" {>= "1.10.1"}
+  "coq-elpi" {>= "1.15.0"}
 ]
 
 tags: [

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -169,8 +169,8 @@ Lemma vcgen_25 (n m jt j it i : F) :
   1 = -(2%:R) * i + it.
 Proof.
 move=> *.
-(* lra. *)
-Abort.
+lra.
+Qed.
 
 Lemma l1 x y z : `|x - z| <= `|x - y| + `|y - z|.
 Proof.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -126,8 +126,8 @@ Qed.
 Lemma plus_minus' x y : 0 = x + y -> 0 = x - y -> 0 = x /\ 0 = y.
 Proof.
 move=> *.
-(* lra. *)
-Abort.
+lra.
+Qed.
 
 Lemma cst_test : 5%:R^+5 = 5%:R * 5%:R * 5%:R * 5%:R * 5%:R :> F.
 Proof.
@@ -137,8 +137,8 @@ Qed.
 Goal forall x y, x <> x -> x > y.
 Proof.
 move=> *.
-(* lra. *)
-Abort.
+lra.
+Qed.
 
 Lemma binomial x y : (x + y)^+2 = x^+2 + 2%:R * x * y + y^+2.
 Proof.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -258,8 +258,8 @@ Qed.
 
 Goal ratr (1 / 2%:R) = 1 / 2%:R :> F.
 Proof.
-Fail lra.  (* TODO should work *)
-Abort.
+lra.
+Qed.
 
 Goal 1 ^+ (2 + 2) = 1 :> F.
 Proof.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -104,7 +104,7 @@ Proof.
 lra.
 Qed.
 
-Lemma test_rat_constant x : 0 <= x -> 1 / 3 * x <= 2^-1 * x.
+Lemma test_rat_constant x : 0 <= x -> 1 / 3%:R * x <= 2%:R^-1 * x.
 Proof.
 lra.
 Qed.
@@ -155,8 +155,8 @@ Lemma vcgen_25 (n m jt j it i : F) :
   1 * it + -(2%:R) * i + -(1%:R) = 0 ->
   1 * jt + -(2%:R) * j + -(1%:R) = 0 ->
   1 * n + -(10%:R) = 0 ->
-  0 <= -(4028%:R)  * i + 6222%:R * j + 705%:R * m + -(16674%:R) ->
-  0 <= -(418%:R) * i + 651%:R * j + 94 %:R * m + -(1866%:R) ->
+  0 <= (* -(4028%:R)  * i + *) 6222%:R * j + 705%:R * m + -(16674%:R) ->
+  0 <= -(418%:R) * i + 651%:R * j + 94 %:R * m (* + -(1866%:R) *) ->
   0 <= -(209%:R) * i + 302%:R * j + 47%:R * m + -(839%:R) ->
   0 <= -(1%:R) * i + 1 * j + -(1%:R) ->
   0 <= -(1%:R) * j + 1 * m + 0 ->
@@ -165,8 +165,9 @@ Lemma vcgen_25 (n m jt j it i : F) :
   0 <= 7%:R * j + 10%:R * m + -(74%:R) ->
   0 <= 18%:R * j + -(139%:R) * m + 1188%:R ->
   0 <= 1  * i + 0 ->
-  0 <= 121%:R  * i + 810%:R  * j + -(7465%:R) * m + 64350%:R ->
+  0 <= 121%:R  * i + 810%:R * j + -(7465%:R) * m + 64350%:R ->
   1 = -(2%:R) * i + it.
+  (* some constants commented out because they are very slow to parse *)
 Proof.
 move=> *.
 lra.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -101,8 +101,8 @@ Qed.
 
 Lemma test_exfalso x (xle2 : x <= 2%:R) (xge3 : x >= 3%:R) : bool.
 Proof.
-(* lra. *)
-Abort.
+lra.
+Qed.
 
 Lemma test_rat_constant x : 0 <= x -> 1 / 3 * x <= 2^-1 * x.
 Proof.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -194,51 +194,51 @@ Qed.
 Goal forall x y, x = 0 -> x * y = 0.
 Proof.
 move=> *.
-(* nra. *)
-Abort.
+nra.
+Qed.
 
 Goal forall x y, 2%:R * x = 0 -> x * y = 0.
 Proof.
 move=> *.
-(* nra. *)
-Abort.
+nra.
+Qed.
 
 Goal forall x y, - x * x >= 0 -> x * y = 0.
 Proof.
 move=> *.
-(* nra. *)
-Abort.
+nra.
+Qed.
 
 Goal forall x, x * x >= 0.
 Proof.
 move=> *.
-(* nra. *)
-Abort.
+nra.
+Qed.
 
 Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
 Proof.
 move=> *.
-(* psatz 3. *)
-Abort.
+psatz 3.
+Qed.
 
 Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
 Proof.
 move=> *.
-(* nra. *)
-Abort.
+nra.
+Qed.
 
 Lemma motzkin' x y :
   (x^+2 + y^+2 + 1) * (x^+2 * y^+4 + x^+4*y^+2 + 1 - 3%:R * x^+2 * y^+2) >= 0.
 Proof.
 move=> *.
-(* psatz 3. *)
-Abort.
+psatz 3.
+Qed.
 
 Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
 Proof.
 move=> *.
-(* nra. *)
-Abort.
+nra.
+Qed.
 
 Goal 1 / (1 - 1) = 0 :> F.
 Proof.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -219,8 +219,10 @@ Qed.
 Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
 Proof.
 move=> *.
-psatz 3.
-Qed.
+(* Requires CSDP *)
+(* psatz 3. *)
+(* Qed. *)
+Abort.
 
 Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
 Proof.
@@ -232,8 +234,10 @@ Lemma motzkin' x y :
   (x^+2 + y^+2 + 1) * (x^+2 * y^+4 + x^+4*y^+2 + 1 - 3%:R * x^+2 * y^+2) >= 0.
 Proof.
 move=> *.
-psatz 3.
-Qed.
+(* Requires CSDP *)
+(* psatz 3. *)
+(* Qed. *)
+Abort.
 
 Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
 Proof.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -1,0 +1,276 @@
+From mathcomp Require Import all_ssreflect ssralg ssrnum rat.
+From mathcomp Require Import lra.
+
+Local Open Scope ring_scope.
+
+Lemma test (F : realFieldType) (x y : F) :
+  x + 2%:R * y <= 3%:R -> 2%:R * x + y <= 3%:R -> x + y <= 2%:R.
+Proof.
+lra.
+Qed.
+
+(* Print test. *)
+(* Print Assumptions test.  (* Closed under the global context *) *)
+
+Lemma test_rat (x y : rat) :
+  x + 2%:R * y <= 3%:R -> 2%:R * x + y <= 3%:R -> x + y <= 2%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_realDomain (F : realDomainType) (x y : F) :
+  x + 2%:R * y <= 3%:R -> 2%:R * x + y <= 3%:R -> x + y <= 2%:R.
+Proof.
+(* lra. *)
+Abort.
+
+Section Tests.
+
+Variable F : realFieldType.
+
+Implicit Types x y : F.
+
+Lemma test_lt x y :
+  x + 2%:R * y < 3%:R -> 2%:R * x + y <= 3%:R -> x + y < 2%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_eq x y :
+  x + 2%:R * y = 3%:R -> 2%:R * x + y <= 3%:R -> x + y <= 2%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_eqop x y :
+  x + 2%:R * y == 3%:R -> 2%:R * x + y <= 3%:R -> x + y <= 2%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_prop_in_middle (C : Prop) x :
+  x <= 2%:R -> C -> x <= 3%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_opp x : x <= 2%:R -> -x >= -2%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_iff x : x <= 2%:R <-> -x >= -2%:R.
+Proof.
+lra.
+Qed.
+
+Lemma test_eq_bool x : x <= 2%:R = (-x >= -2%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_not x : x <= 2%:R -> ~ (x > 2%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_negb x : x <= 2%:R -> ~~ (x > 2%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_and x : x <= 2%:R -> (x <= 3%:R /\ x <= 4%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_andb x : x <= 2%:R -> (x <= 3%:R) && (x <= 4%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_or x : x <= 2%:R -> (x <= 3%:R \/ x <= 1%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_orb x : x <= 2%:R -> (x <= 3%:R) || (x <= 1%:R).
+Proof.
+lra.
+Qed.
+
+Lemma test_exfalso x (xle2 : x <= 2%:R) (xge3 : x >= 3%:R) : bool.
+Proof.
+(* lra. *)
+Abort.
+
+Lemma test_rat_constant x : 0 <= x -> 1 / 3 * x <= 2^-1 * x.
+Proof.
+lra.
+Qed.
+
+End Tests.
+
+(* Examples from the test suite of Coq *)
+Section TestsCoq.
+
+Variable F : realFieldType.
+
+Implicit Types x y : F.
+
+Lemma plus_minus x y : 0 = x + y -> 0 = x - y -> 0 = x /\ 0 = y.
+Proof.
+lra.
+Qed.
+
+Lemma plus_minus' x y : 0 = x + y -> 0 = x - y -> 0 = x /\ 0 = y.
+Proof.
+move=> *.
+(* lra. *)
+Abort.
+
+Lemma cst_test : 5%:R^+5 = 5%:R * 5%:R * 5%:R * 5%:R * 5%:R :> F.
+Proof.
+lra.
+Qed.
+
+Goal forall x y, x <> x -> x > y.
+Proof.
+move=> *.
+(* lra. *)
+Abort.
+
+Lemma binomial x y : (x + y)^+2 = x^+2 + 2%:R * x * y + y^+2.
+Proof.
+move=> *.
+lra.
+Qed.
+
+Lemma hol_light19 x y : 2%:R * y + x = (x + y) + y.
+Proof.
+lra.
+Qed.
+
+Lemma vcgen_25 (n m jt j it i : F) :
+  1 * it + -(2%:R) * i + -(1%:R) = 0 ->
+  1 * jt + -(2%:R) * j + -(1%:R) = 0 ->
+  1 * n + -(10%:R) = 0 ->
+  0 <= -(4028%:R)  * i + 6222%:R * j + 705%:R * m + -(16674%:R) ->
+  0 <= -(418%:R) * i + 651%:R * j + 94 %:R * m + -(1866%:R) ->
+  0 <= -(209%:R) * i + 302%:R * j + 47%:R * m + -(839%:R) ->
+  0 <= -(1%:R) * i + 1 * j + -(1%:R) ->
+  0 <= -(1%:R) * j + 1 * m + 0 ->
+  0 <= 1 * j + 5%:R * m + -(27%:R) ->
+  0 <= 2%:R * j + -(1%:R) * m + 2%:R ->
+  0 <= 7%:R * j + 10%:R * m + -(74%:R) ->
+  0 <= 18%:R * j + -(139%:R) * m + 1188%:R ->
+  0 <= 1  * i + 0 ->
+  0 <= 121%:R  * i + 810%:R  * j + -(7465%:R) * m + 64350%:R ->
+  1 = -(2%:R) * i + it.
+Proof.
+move=> *.
+(* lra. *)
+Abort.
+
+Lemma l1 x y z : `|x - z| <= `|x - y| + `|y - z|.
+Proof.
+Fail intros; split_Rabs; lra.  (* TODO should work *)
+Abort.
+
+Lemma l2 x y :
+  x < `|y| -> y < 1 -> x >= 0 -> - y <= 1 -> `|x| <= 1.
+Proof.
+Fail intros; split_Rabs; lra.  (* TODO should work *)
+Abort.
+
+(*  Bug 5073 *)
+Lemma opp_eq_0_iff x : -x = 0 <-> x = 0.
+Proof.
+lra.
+Qed.
+
+(* From L. Théry *)
+
+Goal forall x y, x = 0 -> x * y = 0.
+Proof.
+move=> *.
+(* nra. *)
+Abort.
+
+Goal forall x y, 2%:R * x = 0 -> x * y = 0.
+Proof.
+move=> *.
+(* nra. *)
+Abort.
+
+Goal forall x y, - x * x >= 0 -> x * y = 0.
+Proof.
+move=> *.
+(* nra. *)
+Abort.
+
+Goal forall x, x * x >= 0.
+Proof.
+move=> *.
+(* nra. *)
+Abort.
+
+Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
+Proof.
+move=> *.
+(* psatz 3. *)
+Abort.
+
+Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
+Proof.
+move=> *.
+(* nra. *)
+Abort.
+
+Lemma motzkin' x y :
+  (x^+2 + y^+2 + 1) * (x^+2 * y^+4 + x^+4*y^+2 + 1 - 3%:R * x^+2 * y^+2) >= 0.
+Proof.
+move=> *.
+(* psatz 3. *)
+Abort.
+
+Goal forall x, -x^+2 >= 0 -> x - 1 >= 0 -> False.
+Proof.
+move=> *.
+(* nra. *)
+Abort.
+
+Goal 1 / (1 - 1) = 0 :> F.
+Proof.
+Fail lra. (* division by zero *)
+Abort.
+
+Goal 0 / (1 - 1) = 0 :> F.
+Proof.
+lra.  (* 0 * x = 0 *)
+Qed.
+
+Goal 10%:R ^+ 2 = 100%:R :> F.
+Proof.
+(* pow is reified as a constant *)
+lra.
+Qed.
+
+Goal ratr (1 / 2%:R) = 1 / 2%:R :> F.
+Proof.
+Fail lra.  (* TODO should work *)
+Abort.
+
+Goal 1 ^+ (2 + 2) = 1 :> F.
+Proof.
+lra.
+Qed.
+
+(* Instance Dplus : DeclaredConstant addn := {}. *)  (* TODO should work *)
+
+Goal 1 ^+ (2 + 2) = 1 :> F.
+Proof.
+lra.
+Qed.
+
+End TestsCoq.

--- a/examples/lra_examples.v
+++ b/examples/lra_examples.v
@@ -21,8 +21,8 @@ Qed.
 Lemma test_realDomain (F : realDomainType) (x y : F) :
   x + 2%:R * y <= 3%:R -> 2%:R * x + y <= 3%:R -> x + y <= 2%:R.
 Proof.
-(* lra. *)
-Abort.
+lra.
+Qed.
 
 Section Tests.
 

--- a/meta.yml
+++ b/meta.yml
@@ -9,17 +9,19 @@ synopsis: >-
   Ring and field tactics for Mathematical Components
 
 description: |-
-  This library provides `ring` and `field` tactics for Mathematical Components,
-  that work with any `comRingType` and `fieldType` instances, respectively.
-  Their instance resolution is done through canonical structure inference.
-  Therefore, they work with abstract rings and do not require `Add Ring` and
-  `Add Field` commands. Another key feature of this library is that they
-  automatically push down ring morphisms and additive functions to leaves of
-  ring/field expressions before normalization to the Horner form.
+  This library provides `ring`, `field`, and `lra` tactics for Mathematical
+  Components, that work with any `comRingType`, `fieldType`, and
+  `realDomainType` or `realFieldType` instances, respectively. Their instance
+  resolution is done through canonical structure inference.  Therefore, they
+  work with abstract rings and do not require `Add Ring` and `Add Field`
+  commands. Another key feature of this library is that they automatically push
+  down ring morphisms and additive functions to leaves of ring/field expressions
+  before applying the proof procedures.
 
 publications:
-- pub_url: https://arxiv.org/abs/2202.04330
+- pub_url: https://drops.dagstuhl.de/opus/volltexte/2022/16738/
   pub_title: Reflexive tactics for algebra, revisited
+  pub_doi: 10.4230/LIPIcs.ITP.2022.29
 
 authors:
 - name: Kazuhiko Sakaguchi
@@ -33,44 +35,14 @@ license:
   file: CeCILL-B
 
 supported_coq_versions:
-  text: 8.13 or later
-  opam: '{>= "8.13"}'
+  text: 8.16 or later
+  opam: '{>= "8.16"}'
 
 tested_coq_nix_versions:
 
 tested_coq_opam_versions:
-- version: '1.12.0-coq-8.13'
-  repo: 'mathcomp/mathcomp'
-- version: '1.12.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.13'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.15'
-  repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-8.13'
-  repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-8.15'
-  repo: 'mathcomp/mathcomp'
-- version: '1.15.0-coq-8.13'
-  repo: 'mathcomp/mathcomp'
-- version: '1.15.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.15.0-coq-8.15'
-  repo: 'mathcomp/mathcomp'
 - version: '1.15.0-coq-8.16'
   repo: 'mathcomp/mathcomp'
-- version: '1.15.0-coq-dev'
-  repo: 'mathcomp/mathcomp'
-- version: 'coq-8.13'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.14'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.15'
-  repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.16'
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-dev'
@@ -79,9 +51,9 @@ tested_coq_opam_versions:
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{>= "1.12"}'
+    version: '{>= "1.15"}'
   description: |-
-    [MathComp](https://math-comp.github.io) ssreflect 1.12 or later
+    [MathComp](https://math-comp.github.io) ssreflect 1.15 or later
 - opam:
     name: coq-mathcomp-algebra
   description: |-
@@ -93,9 +65,9 @@ dependencies:
     [Mczify](https://github.com/math-comp/mczify) 1.1.0 or later
 - opam:
     name: coq-elpi
-    version: '{>= "1.10.1"}'
+    version: '{>= "1.15.0"}'
   description: |-
-    [Coq-Elpi](https://github.com/LPCIC/coq-elpi) 1.10.1 or later
+    [Coq-Elpi](https://github.com/LPCIC/coq-elpi) 1.15.0 or later
 
 namespace: mathcomp.algebra_tactics
 

--- a/theories/compat815.elpi
+++ b/theories/compat815.elpi
@@ -1,7 +1,0 @@
-solve (goal _Ctx _Trigger _Type _Proof
-       [str Tac815, str Tac816, N, F, FQ, E, F'] as G) GL :-
-  coq.version _Str _Major Minor _Patch,
-  (if (Minor i< 16)
-     (coq.ltac.call Tac815 [N, FQ, E, F'] G GL)
-     (coq.ltac.call Tac816 [N, F, F'] G GL);
-   coq.ltac.fail 0).

--- a/theories/compat815.elpi
+++ b/theories/compat815.elpi
@@ -1,0 +1,7 @@
+solve (goal _Ctx _Trigger _Type _Proof
+       [str Tac815, str Tac816, N, F, FQ, E, F'] as G) GL :-
+  coq.version _Str _Major Minor _Patch,
+  (if (Minor i< 16)
+     (coq.ltac.call Tac815 [N, FQ, E, F'] G GL)
+     (coq.ltac.call Tac816 [N, F, F'] G GL);
+   coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -299,7 +299,11 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Main tactic
 
-% This calls the Ltac1 tactic "lraF" with the following arguments:
+% The tactic takes two arguments, a string [Tac]
+% that is the name of the Ltac1 tactic to call and a second argument [N],
+% passed unchanged as first argument to the previous tactic.
+% The tactic [Tac] will receive five arguments:
+% - [N] above
 % - [Efalso] a term of type [bool] indicating if the goal was changed to [False]
 % - [Type''] a term of type [Prop], an implication with the goal
 %   and selected hypotheses
@@ -307,7 +311,7 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
 %   [realFieldType]
-solve (goal Ctx _Trigger Type _Proof _Args as G) GL :-
+solve (goal Ctx _Trigger Type _Proof [str Tac, N] as G) GL :-
   exfalso_if_not_prop Type Type' Efalso,
   std.rev Ctx Ctx', !,
   fstr Ctx' Type' F, !,
@@ -321,5 +325,5 @@ solve (goal Ctx _Trigger Type _Proof _Args as G) GL :-
     {{ Internals.vm_of_list lp:VM' }}
     {{ VarMap.t lp:FS }}
     VM'',
-  (coq.ltac.call "lraF" [trm Efalso, trm Type'', trm TypeF', trm VM''] G GL;
+  (coq.ltac.call Tac [N, trm Efalso, trm Type'', trm TypeF', trm VM''] G GL;
    coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -31,9 +31,13 @@ pred reduction-Z i:term, o:term.
 reduction-Z I O :- coq.reduction.vm.norm I {{ Z }} O, ground-Z O.
 
 pred nat->N i:term, o:term.
+nat->N {{ Init.Nat.of_num_uint lp:X }} XN :-
+  reduction-N {{ N.of_num_uint lp:X }} XN.
 nat->N {{ lp:X }} XN :- reduction-N {{ N.of_nat lp:X }} XN.
 
 pred nat->Z i:term, o:term.
+nat->Z {{ Init.Nat.of_num_uint lp:X }} XZ :-
+  reduction-Z {{ Z.of_num_uint lp:X }} XZ.
 nat->Z {{ lp:X }} XZ :- reduction-Z {{ Z.of_nat lp:X }} XZ.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -142,23 +142,28 @@ rfstr _ _ _ :- coq.ltac.fail _ "Cannot find a realDomainType".
 % - [In] is a term of type [V],
 % - [OutM] is a reified constant of type [MExpr V]
 % - [Out] is a reified constant of type [PExpr Q]
-pred quote.cstr i:term, i:term, o:term, o:term.
-quote.cstr V {{ GRing.zero lp:Z }} OutM Out :- ring->zmod V Z,
-  OutM = {{ @Internals.MEint lp:V Z0 }}, Out = {{ PEc (Qmake Z0 1) }}.
-quote.cstr V {{ GRing.one lp:V' }} OutM Out :- coq.unify-eq V V' ok,
-  OutM = {{ @Internals.MEint lp:V (Zpos 1) }}, Out = {{ PEc (Qmake 1 1) }}.
-quote.cstr V {{ @GRing.natmul lp:Z (GRing.one lp:V') lp:X }} OutM Out :-
+% - [OutQ] the reified [Out] as a [Q] (for <= 8.15 compat)
+pred quote.cstr i:term, i:term, o:term, o:term, o:term.
+quote.cstr V {{ GRing.zero lp:Z }} OutM Out OutQ :- ring->zmod V Z,
+  OutM = {{ @Internals.MEint lp:V Z0 }}, Out = {{ PEc (Qmake Z0 1) }},
+  OutQ = {{ Qmake Z0 1 }}.
+quote.cstr V {{ GRing.one lp:V' }} OutM Out OutQ :- coq.unify-eq V V' ok,
+  OutM = {{ @Internals.MEint lp:V (Zpos 1) }}, Out = {{ PEc (Qmake 1 1) }},
+  OutQ = {{ Qmake 1 1 }}.
+quote.cstr V {{ @GRing.natmul lp:Z (GRing.one lp:V') lp:X }} OutM Out OutQ :-
   ring->zmod V Z, coq.unify-eq V V' ok, nat->Z X XZ,
-  OutM = {{ @Internals.MEint lp:V lp:XZ }}, Out = {{ PEc (Qmake lp:XZ 1) }}.
+  OutM = {{ @Internals.MEint lp:V lp:XZ }}, Out = {{ PEc (Qmake lp:XZ 1) }},
+  OutQ = {{ Qmake lp:XZ 1 }}.
 
 % [quote.cstf V In OutM Out] reifies rational constants
 % - [V] is a [ringType] instance,
 % - [In] is a term of type [V],
 % - [OutM] is a reified constant of type [MExpr V]
 % - [Out] is a reified constant of type [PExpr Q]
-pred quote.cstf i:term, i:term, o:term, o:term.
+% - [OutQ] the reified [Out] as a [Q] (for <= 8.15 compat)
+pred quote.cstf i:term, i:term, o:term, o:term, o:term.
 quote.cstf V {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:V') lp:X) }}
-    OutM Out :- unitRing->ring U V, ring->zmod V Z, coq.unify-eq V V' ok,
+    OutM Out XQ :- unitRing->ring U V, ring->zmod V Z, coq.unify-eq V V' ok,
   nat->N X XN, XN = {{ Npos lp:XP }}, XQ = {{ Qmake 1 lp:XP }},
   field->unitRing F U,
   OutM = {{ @Internals.MErat lp:F lp:XQ }}, Out = {{ PEc lp:XQ }}.
@@ -169,109 +174,135 @@ quote.cstf V {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:V') lp:X) }}
 % - [In] is a term of type [V],
 % - [OutM] is a reified expression of type [MExpr V]
 % - [Out] is a reified expression of type [PExpr Q]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [V].
-pred quote.expr i:term, i:(term -> term), i:term, o:term, o:term, o:list term.
-quote.expr V F {{ @GRing.add lp:Z lp:In1 lp:In2 }} OutM Out VM :-
+pred quote.expr i:term, i:(term -> term), i:term,
+    o:term, o:term, o:term, o:list term.
+quote.expr V F {{ @GRing.add lp:Z lp:In1 lp:In2 }} OutM Out OutQ VM :-
   ring->zmod V Z, !,
-  quote.expr V F In1 OutM1 Out1 VM, !, quote.expr V F In2 OutM2 Out2 VM, !,
+  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
+  quote.expr V F In2 OutM2 Out2 OutQ2 VM, !,
   OutM = {{ @Internals.MEadd lp:V lp:OutM1 lp:OutM2 }},
-  Out = {{ PEadd lp:Out1 lp:Out2 }}.
-quote.expr V F {{ @GRing.mul lp:V' lp:In1 lp:In2 }} OutM Out VM :-
+  Out = {{ PEadd lp:Out1 lp:Out2 }},
+  OutQ = {{ (lp:OutQ1 + lp:OutQ2)%Q }}.
+quote.expr V F {{ @GRing.mul lp:V' lp:In1 lp:In2 }} OutM Out OutQ VM :-
   coq.unify-eq V V' ok, !,
-  quote.expr V F In1 OutM1 Out1 VM, !, quote.expr V F In2 OutM2 Out2 VM, !,
+  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
+  quote.expr V F In2 OutM2 Out2 OutQ2 VM, !,
   OutM = {{ @Internals.MEmul lp:V lp:OutM1 lp:OutM2 }},
-  Out = {{ PEmul lp:Out1 lp:Out2 }}.
-quote.expr V F {{ @GRing.opp lp:Z lp:In1 }} OutM Out VM :-
+  Out = {{ PEmul lp:Out1 lp:Out2 }},
+  OutQ = {{ (lp:OutQ1 * lp:OutQ2)%Q }}.
+quote.expr V F {{ @GRing.opp lp:Z lp:In1 }} OutM Out OutQ VM :-
   ring->zmod V Z, !,
-  quote.expr V F In1 OutM1 Out1 VM, !,
-  OutM = {{ @Internals.MEopp lp:V lp:OutM1 }}, Out = {{ PEopp lp:Out1 }}.
-quote.expr V F {{ @GRing.exp lp:V' lp:In1 lp:X }} OutM Out VM :-
+  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
+  OutM = {{ @Internals.MEopp lp:V lp:OutM1 }}, Out = {{ PEopp lp:Out1 }},
+  OutQ = {{ (- lp:OutQ1)%Q }}.
+quote.expr V F {{ @GRing.exp lp:V' lp:In1 lp:X }} OutM Out OutQ VM :-
   coq.unify-eq V V' ok, nat->N X XN, !,
-  quote.expr V F In1 OutM1 Out1 VM, !,
+  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
   OutM = {{ @Internals.MEpow lp:V lp:OutM1 lp:XN }},
-  Out = {{ PEpow lp:Out1 lp:XN }}.
-quote.expr V _ In OutM Out _ :- quote.cstr V In OutM Out.
-quote.expr V _ In OutM Out _ :- field-mode, quote.cstf V In OutM Out.
-quote.expr V F In {{ @Internals.MEmorph lp:U lp:V lp:G lp:OutM }} Out VM :-
+  Out = {{ PEpow lp:Out1 lp:XN }},
+  nat->Z X XZ, OutQ = {{ (lp:OutQ1 ^ lp:XZ)%Q }}.
+quote.expr V _ In OutM Out OutQ _ :- quote.cstr V In OutM Out OutQ.
+quote.expr V _ In OutM Out OutQ _ :- field-mode, quote.cstf V In OutM Out OutQ.
+quote.expr V F In {{ @Internals.MEmorph lp:U lp:V lp:G lp:OutM }} Out OutQ VM :-
   coq.unify-eq
     {{ @GRing.RMorphism.apply lp:U lp:V lp:Ph lp:G lp:In1 }} In ok, !,
   quote.expr U (x\ F {{ @GRing.RMorphism.apply lp:U lp:V lp:Ph lp:G lp:x }})
-    In1 OutM Out VM.
-quote.expr V F In {{ @Internals.MEX lp:V lp:In }} {{ PEX lp:N }} VM :- !,
-  mem VM (F In) N.
+    In1 OutM Out OutQ VM.
+quote.expr V F In {{ @Internals.MEX lp:V lp:In }} {{ PEX lp:N }} OutQ VM :- !,
+  FIn = F In,
+  mem VM FIn N,
+  OutQ = {{ @Internals.R2Q lp:V lp:FIn }}.
 
 % [quote.exprw F In OutM Out VM] reifies arithmetic expressions
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [F],
 % - [OutM] is a reified expression of type [MExpr F]
 % - [Out] is a reified expression of type [PExpr Q]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.exprw i:rf, i:term, o:term, o:term, o:list term.
-quote.exprw F In OutM Out VM :- F = field _, !,
-  field-mode => quote.expr { rf->ring F } (x\ x) In OutM Out VM.
-quote.exprw F In OutM Out VM :- F = ring _, !,
-  quote.expr { rf->ring F } (x\ x) In OutM Out VM.
+pred quote.exprw i:rf, i:term, o:term, o:term, o:term, o:list term.
+quote.exprw F In OutM Out OutQ VM :- F = field _, !,
+  field-mode => quote.expr { rf->ring F } (x\ x) In OutM Out OutQ VM.
+quote.exprw F In OutM Out OutQ VM :- F = ring _, !,
+  quote.expr { rf->ring F } (x\ x) In OutM Out OutQ VM.
 
 % [quote.bop2 F In OutM Out VM] reifies boolean (in)equalities
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [bool],
 % - [OutM] is a reified expression of type [MFormula]
 % - [Out] is a reified expression of type [Formula Q]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.bop2 i:rf, i:term, o:term, o:term, o:list term.
-quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} OutM Out VM :- rf->porder F O, !,
-  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+pred quote.bop2 i:rf, i:term, o:term, o:term, o:term, o:list term.
+quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} OutM Out OutQ VM :-
+  rf->porder F O, !,
+  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
   OutM = {{ Internals.Build_MFormula lp:XM' OpLe lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpLe lp:Y' }}.
-quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} OutM Out VM :- rf->porder F O, !,
-  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+  Out = {{ Build_Formula lp:X' OpLe lp:Y' }},
+  OutQ = {{ (lp:XQ' <= lp:YQ')%Q }}.
+quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} OutM Out OutQ VM :-
+  rf->porder F O, !,
+  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
   OutM = {{ Internals.Build_MFormula lp:XM' OpLt lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpLt lp:Y' }}.
-quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} OutM Out VM :- rf->eq F T, !,
-  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+  Out = {{ Build_Formula lp:X' OpLt lp:Y' }},
+  OutQ = {{ (lp:XQ' < lp:YQ')%Q }}.
+quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} OutM Out OutQ VM :-
+  rf->eq F T, !,
+  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
   OutM = {{ Internals.Build_MFormula lp:XM' OpEq lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpEq lp:Y' }}.
+  Out = {{ Build_Formula lp:X' OpEq lp:Y' }},
+  OutQ = {{ (lp:XQ' == lp:YQ')%Q }}.
 
 % [quote.pop2 F In OutM Out VM] reifies (in)equalities of type Prop
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
 % - [OutM] is a reified expression of type [MFormula]
 % - [Out] is a reified expression of type [Formula Q]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.pop2 i:rf, i:term, o:term, o:term, o:list term.
-quote.pop2 F {{ is_true lp:E }} OutM Out VM :- quote.bop2 F E OutM Out VM.
-quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} OutM Out VM :- rf->sort F T, !,
-  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+pred quote.pop2 i:rf, i:term, o:term, o:term, o:term, o:list term.
+quote.pop2 F {{ is_true lp:E }} OutM Out OutQ VM :-
+  quote.bop2 F E OutM Out OutQ VM.
+quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} OutM Out OutQ VM :- rf->sort F T, !,
+  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
   OutM = {{ Internals.Build_MFormula lp:XM' OpEq lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpEq lp:Y' }}.
+  Out = {{ Build_Formula lp:X' OpEq lp:Y' }},
+  OutQ = {{ (lp:XQ' == lp:YQ')%Q }}.
 
 % [quote.bool F In OutM Out VM] reifies boolean formulas
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [bool],
 % - [OutM] is a reified formula of type [BFormula MFormula Tauto.isBool]
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isBool]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.bool i:rf, i:term, o:term, o:term, o:list term.
-quote.bool F {{ lp:F1 ==> lp:F2 }} OutM Out VM :- !,
-  quote.bool F F1 OutM1 Out1 VM, !, quote.bool F F2 OutM2 Out2 VM, !,
+pred quote.bool i:rf, i:term, o:term, o:term, o:term, o:list term.
+quote.bool F {{ lp:F1 ==> lp:F2 }} OutM Out OutQ VM :- !,
+  quote.bool F F1 OutM1 Out1 OutQ1 VM, !, quote.bool F F2 OutM2 Out2 OutQ2 VM,
   OutM = {{ IMPL lp:OutM1 None lp:OutM2 }},
-  Out = {{ IMPL lp:Out1 None lp:Out2 }}.
-quote.bool F {{ lp:F1 && lp:F2 }} OutM Out VM :- !,
-  quote.bool F F1 OutM1 Out1 VM, !, quote.bool F F2 OutM2 Out2 VM, !,
-  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }}.
-quote.bool F {{ lp:F1 || lp:F2 }} OutM Out VM :- !,
-  quote.bool F F1 OutM1 Out1 VM, !, quote.bool F F2 OutM2 Out2 VM, !,
-  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }}.
-quote.bool F {{ ~~ lp:F1 }} OutM Out VM :- !, quote.bool F F1 OutM1 Out1 VM, !,
-  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}.
-quote.bool _ {{ true }} OutM Out _ :- !,
-  OutM = {{ TT Tauto.isBool }}, Out = {{ TT Tauto.isBool }}.
-quote.bool _ {{ false }} OutM Out _ :- !,
-  OutM = {{ FF Tauto.isBool }}, Out = {{ FF Tauto.isBool }}.
-quote.bool F In OutM Out VM :- quote.bop2 F In OutM' Out' VM,
+  Out = {{ IMPL lp:Out1 None lp:Out2 }},
+  OutQ = {{ lp:OutQ1 -> lp:OutQ2 }}.
+quote.bool F {{ lp:F1 && lp:F2 }} OutM Out OutQ VM :- !,
+  quote.bool F F1 OutM1 Out1 OutQ1 VM, !, quote.bool F F2 OutM2 Out2 OutQ2 VM,
+  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }},
+  OutQ = {{ lp:OutQ1 /\ lp:OutQ2 }}.
+quote.bool F {{ lp:F1 || lp:F2 }} OutM Out OutQ VM :- !,
+  quote.bool F F1 OutM1 Out1 OutQ1 VM, !, quote.bool F F2 OutM2 Out2 OutQ2 VM,
+  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }},
+  OutQ = {{ lp:OutQ1 \/ lp:OutQ2 }}.
+quote.bool F {{ ~~ lp:F1 }} OutM Out OutQ VM :- !,
+  quote.bool F F1 OutM1 Out1 OutQ1 VM, !,
+  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}, OutQ = {{ ~ lp:OutQ1 }}.
+quote.bool _ {{ true }} OutM Out OutQ _ :- !,
+  OutM = {{ TT Tauto.isBool }}, Out = {{ TT Tauto.isBool }}, OutQ = {{ True }}.
+quote.bool _ {{ false }} OutM Out OutQ _ :- !,
+  OutM = {{ FF Tauto.isBool }}, Out = {{ FF Tauto.isBool }}, OutQ = {{ False }}.
+quote.bool F In OutM Out OutQ VM :- quote.bop2 F In OutM' Out' OutQ VM,
   OutM = {{ A Tauto.isBool lp:OutM' tt }},
   Out = {{ A Tauto.isBool lp:Out' tt }}.
-quote.bool _ In OutM Out _ :-
+quote.bool _ In OutM Out In _ :-
   OutM = {{ X Tauto.isBool lp:In }}, Out = {{ X Tauto.isBool lp:In }}.
 
 % [quote.prop F In OutM Out VM] reifies formulas of type Prop
@@ -279,38 +310,46 @@ quote.bool _ In OutM Out _ :-
 % - [In] is a term of type [Prop],
 % - [OutM] is a reified formula of type [BFormula MFormula Tauto.isProp]
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.prop i:rf, i:term, o:term, o:term, o:list term.
-quote.prop F {{ lp:F1 -> lp:F2 }} OutM Out VM :- !,
-  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
+pred quote.prop i:rf, i:term, o:term, o:term, o:term, o:list term.
+quote.prop F {{ lp:F1 -> lp:F2 }} OutM Out OutQ VM :- !,
+  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
   OutM = {{ IMPL lp:OutM1 None lp:OutM2 }},
-  Out = {{ IMPL lp:Out1 None lp:Out2 }}.
-quote.prop F {{ iff lp:F1 lp:F2 }} OutM Out VM :- !,
-  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
-  OutM = {{ IFF lp:OutM1 lp:OutM2 }}, Out = {{ IFF lp:Out1 lp:Out2 }}.
-quote.prop F {{ lp:F1 /\ lp:F2 }} OutM Out VM :- !,
-  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
-  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }}.
-quote.prop F {{ lp:F1 \/ lp:F2 }} OutM Out VM :- !,
-  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
-  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }}.
-quote.prop F {{ ~ lp:F1 }} OutM Out VM :- !, quote.prop F F1 OutM1 Out1 VM, !,
-  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}.
-quote.prop _ {{ True }} OutM Out _ :- !,
-  OutM = {{ TT Tauto.isProp }}, Out = {{ TT Tauto.isProp }}.
-quote.prop _ {{ False }} OutM Out _ :- !,
-  OutM = {{ FF Tauto.isProp }}, Out = {{ FF Tauto.isProp }}.
-quote.prop F {{ is_true lp:In1 }} OutM Out VM :- !,
-  quote.bool F In1 OutM1 Out1 VM, !,
+  Out = {{ IMPL lp:Out1 None lp:Out2 }},
+  OutQ = {{ lp:OutQ1 -> lp:OutQ2 }}.
+quote.prop F {{ iff lp:F1 lp:F2 }} OutM Out OutQ VM :- !,
+  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
+  OutM = {{ IFF lp:OutM1 lp:OutM2 }}, Out = {{ IFF lp:Out1 lp:Out2 }},
+  OutQ = {{ iff lp:OutQ1 lp:OutQ2 }}.
+quote.prop F {{ lp:F1 /\ lp:F2 }} OutM Out OutQ VM :- !,
+  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
+  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }},
+  OutQ = {{ lp:OutQ1 /\ lp:OutQ2 }}.
+quote.prop F {{ lp:F1 \/ lp:F2 }} OutM Out OutQ VM :- !,
+  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
+  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }},
+  OutQ = {{ lp:OutQ1 \/ lp:OutQ2 }}.
+quote.prop F {{ ~ lp:F1 }} OutM Out OutQ VM :- !,
+  quote.prop F F1 OutM1 Out1 OutQ1 VM, !,
+  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}, OutQ = {{ ~ lp:OutQ1 }}.
+quote.prop _ {{ True }} OutM Out OutQ _ :- !,
+  OutM = {{ TT Tauto.isProp }}, Out = {{ TT Tauto.isProp }}, OutQ = {{ True }}.
+quote.prop _ {{ False }} OutM Out OutQ _ :- !,
+  OutM = {{ FF Tauto.isProp }}, Out = {{ FF Tauto.isProp }}, OutQ = {{ False }}.
+quote.prop F {{ is_true lp:In1 }} OutM Out OutQ VM :- !,
+  quote.bool F In1 OutM1 Out1 OutQ1 VM, !,
   OutM = {{ EQ lp:OutM1 (TT Tauto.isBool) }},
-  Out = {{ EQ lp:Out1 (TT Tauto.isBool) }}.
-quote.prop F {{ @eq bool lp:In1 lp:In2 }} OutM Out VM :- !,
-  quote.bool F In1 OutM1 Out1 VM, !, quote.bool F In2 OutM2 Out2 VM,
-  OutM = {{ EQ lp:OutM1 lp:OutM2 }}, Out = {{ EQ lp:Out1 lp:Out2 }}.
-quote.prop F In OutM Out VM :- quote.pop2 F In OutM' Out' VM,
+  Out = {{ EQ lp:Out1 (TT Tauto.isBool) }},
+  OutQ = {{ lp:OutQ1 }}.
+quote.prop F {{ @eq bool lp:In1 lp:In2 }} OutM Out OutQ VM :- !,
+  quote.bool F In1 OutM1 Out1 OutQ1 VM, !, quote.bool F In2 OutM2 Out2 OutQ2 VM,
+  OutM = {{ EQ lp:OutM1 lp:OutM2 }}, Out = {{ EQ lp:Out1 lp:Out2 }},
+  OutQ = {{ lp:OutQ1 <-> lp:OutQ2 }}.
+quote.prop F In OutM Out OutQ VM :- quote.pop2 F In OutM' Out' OutQ VM,
   OutM = {{ A Tauto.isProp lp:OutM' tt }},
   Out = {{ A Tauto.isProp lp:Out' tt }}.
-quote.prop _ In OutM Out _ :-
+quote.prop _ In OutM Out In _ :-
   OutM = {{ X Tauto.isProp lp:In }}, Out = {{ X Tauto.isProp lp:In }}.
 
 % [simplify.bool In Out] reduces a boolean formula to [X _]
@@ -368,10 +407,12 @@ simplify.prop X X.
 % - [In] is a term of type [Prop],
 % - [OutM] is a reified formula of type [BFormula MFormula Tauto.isProp]
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
+% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote i:rf, i:term, o:term, o:term, o:list term.
-quote F In OutM' Out' VM :-
-  quote.prop F In OutM Out VM, simplify.prop OutM OutM', simplify.prop Out Out'.
+pred quote i:rf, i:term, o:term, o:term, o:term, o:list term.
+quote F In OutM' Out' OutQ VM :-
+  quote.prop F In OutM Out OutQ VM,
+  simplify.prop OutM OutM', simplify.prop Out Out'.
 
 % [quote.hyps F Hyps Goal ReifiedGoal Out ReifiedOut VM] reifies hypotheses
 % - [F] is a [realDomainType] or [realFieldType] instance,
@@ -379,26 +420,32 @@ quote F In OutM' Out' VM :-
 % - [Goal] is the goal, of type [Prop]
 % - [ReifiedGoalM] is the refied goal as a [BFormula MFormula Tauto.isProp]
 % - [ReifiedGoal] is the refied goal as a [BFormula (Formula Q) Tauto.isProp]
+% - [ReifiedGoalQ] the reified goal as a [Prop] about [Q] (for <= 8.15 compat)
 % - [Out] is a chain of implications including [Goal] and hypotheses in [Hyps]
 %   that have some arithmetic content
 % - [ReifiedOutM] is a reified version of [Out]
 %   as a [BFormula MFormula Tauto.isProp]
 % - [ReifiedOut] is a reified version of [Out]
 %   as a [BFormula (Formula Q) Tauto.isProp]
+% - [ReifiedOutQ] the [ReifiedOut] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.hyps i:rf, i:list prop, i:term, i:term, i:term,
-  o:term, o:term, o:term, o:list term.
-quote.hyps F [decl _ _ H|Ctx] Type TypeFM TypeF Type'' TypeFM'' TypeF'' VM :-
-  quote F H HM' H' VM, not (H' = {{ X _ _ }}), !,
-  quote.hyps F Ctx Type TypeFM TypeF Type' TypeFM' TypeF' VM,
+pred quote.hyps i:rf, i:list prop, i:term, i:term, i:term, i:term,
+  o:term, o:term, o:term, o:term, o:list term.
+quote.hyps F [decl _ _ H|Ctx] Type TypeFM TypeF TypeFQ
+    Type'' TypeFM'' TypeF'' TypeFQ'' VM :-
+  quote F H HM' H' HQ' VM, not (H' = {{ X _ _ }}), !,
+  quote.hyps F Ctx Type TypeFM TypeF TypeFQ Type' TypeFM' TypeF' TypeFQ' VM,
   Type'' = {{ lp:H -> lp:Type' }},
   TypeFM'' = {{ IMPL lp:HM' None lp:TypeFM' }},
-  TypeF'' = {{ IMPL lp:H' None lp:TypeF' }}.
-quote.hyps F [decl _ _ _|Ctx] Type TypeFM TypeF Type' TypeFM' TypeF' VM :- !,
-  quote.hyps F Ctx Type TypeFM TypeF Type' TypeFM' TypeF' VM.
-quote.hyps F [def _ _ _ _|Ctx] Type TypeFM TypeF Type' TypeFM' TypeF' VM :- !,
-  quote.hyps F Ctx Type TypeFM TypeF Type' TypeFM' TypeF' VM.
-quote.hyps _ [] Type TypeFM TypeF Type TypeFM TypeF _.
+  TypeF'' = {{ IMPL lp:H' None lp:TypeF' }},
+  TypeFQ'' = {{ lp:HQ' -> lp:TypeFQ' }}.
+quote.hyps F [decl _ _ _|Ctx] Type TypeFM TypeF TypeFQ
+    Type' TypeFM' TypeF' TypeFQ' VM :- !,
+  quote.hyps F Ctx Type TypeFM TypeF TypeFQ Type' TypeFM' TypeF' TypeFQ' VM.
+quote.hyps F [def _ _ _ _|Ctx] Type TypeFM TypeF TypeFQ
+    Type' TypeFM' TypeF' TypeFQ' VM :- !,
+  quote.hyps F Ctx Type TypeFM TypeF TypeFQ Type' TypeFM' TypeF' TypeFQ' VM.
+quote.hyps _ [] Type TypeFM TypeF TypeFQ Type TypeFM TypeF TypeFQ _.
 
 % [exfalso_if_not_prop In Out Bool] changes [In] to [False]
 % when [In] is not a [Prop] (and then set [Bool] to [true])
@@ -414,13 +461,14 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 % that are the names of the Ltac1 tactic to call respactively
 % in the [realFieldType] and [realDomainType] case and a third argument [N],
 % passed unchanged as first argument to the previous tactic.
-% The tactics [TacF] or [TacR] will receive six arguments:
+% The tactics [TacF] or [TacR] will receive seven arguments:
 % - [N] above
 % - [Efalso] a term of type [bool] indicating if the goal was changed to [False]
 % - [Type''] a term of type [Prop], an implication with the goal
 %   and selected hypotheses
 % - [TypeFM'] the reified [Type''] as a [BFormula MFormula Tauto.isProp]
 % - [TypeF'] the reified [Type''] as a [BFormula (Formula Q) Tauto.isProp]
+% - [TypeFQ'] the reified [Type''] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
 %   [realFieldType] or [realDomainType]
@@ -428,8 +476,9 @@ solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :-
   exfalso_if_not_prop Type Type' Efalso,
   std.rev Ctx Ctx', !,
   rfstr Ctx' Type' F, !,
-  quote F Type' TypeFM TypeF VM, !,
-  quote.hyps F Ctx' Type' TypeFM TypeF Type'' TypeFM' TypeF' VM, !,
+  quote F Type' TypeFM TypeF TypeFQ VM, !,
+  quote.hyps F Ctx' Type' TypeFM TypeF TypeFQ Type'' TypeFM' TypeF' TypeFQ' VM,
+  !,
   rf->numDomain F NDF,
   std.assert-ok!
     (coq.typecheck TypeFM' {{ BFormula (@Internals.MFormula lp:NDF) isProp }})
@@ -444,5 +493,6 @@ solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :-
     VM'',
   (if (F = field _) (Tac = TacF) (Tac = TacR)),
   (coq.ltac.call
-     Tac [N, trm Efalso, trm Type'', trm TypeFM', trm TypeF', trm VM''] G GL;
+     Tac [N, trm Efalso, trm Type'', trm TypeFM', trm TypeF', trm TypeFQ',
+          trm VM''] G GL;
    coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -1,0 +1,281 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Misc utils
+
+pred list-constant o:term, o:list term, o:term.
+list-constant T [] {{ @nil lp:T }} :- !.
+list-constant T [X|XS] {{ @cons lp:T lp:X lp:XS' }} :- list-constant T XS XS'.
+
+pred mem o:list term, o:term, o:term.
+mem [X|_] X {{ 1%positive }}.
+mem [_|XS] X M :- !, mem XS X N,
+  coq.reduction.vm.norm {{ Pos.succ lp:N }} {{ positive }} M.
+
+pred ground-pos i:term.
+ground-pos {{ xH }}.
+ground-pos {{ xO lp:P }} :- !, ground-pos P.
+ground-pos {{ xI lp:P }} :- !, ground-pos P.
+
+pred ground-N i:term.
+ground-N {{ N0 }}.
+ground-N {{ Npos lp:P }} :- !, ground-pos P.
+
+pred ground-Z i:term.
+ground-Z {{ Z0 }}.
+ground-Z {{ Zpos lp:P }} :- !, ground-pos P.
+ground-Z {{ Zneg lp:P }} :- !, ground-pos P.
+
+pred reduction-N i:term, o:term.
+reduction-N I O :- coq.reduction.vm.norm I {{ N }} O, ground-N O.
+
+pred reduction-Z i:term, o:term.
+reduction-Z I O :- coq.reduction.vm.norm I {{ Z }} O, ground-Z O.
+
+pred nat->N i:term, o:term.
+nat->N {{ lp:X }} XN :- reduction-N {{ N.of_nat lp:X }} XN.
+
+pred nat->Z i:term, o:term.
+nat->Z {{ lp:X }} XZ :- reduction-Z {{ Z.of_nat lp:X }} XZ.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Casts from realFieldType to various substructures
+
+pred f->sort o:term, o:term.
+f->sort F T :- coq.unify-eq {{ Num.RealField.sort lp:F }} T ok.
+
+pred f->eq o:term, o:term.
+f->eq F T :- coq.unify-eq {{ Num.RealField.eqType lp:F }} T ok.
+
+pred f->porder o:term, o:term.
+f->porder F T :- coq.unify-eq {{ Num.RealField.porderType lp:F }} T ok.
+
+pred f->zmod o:term, o:term.
+f->zmod F T :- coq.unify-eq {{ Num.RealField.zmodType lp:F }} T ok.
+
+pred f->ring o:term, o:term.
+f->ring F T :- coq.unify-eq {{ Num.RealField.ringType lp:F }} T ok.
+
+pred f->unitRing o:term, o:term.
+f->unitRing F T :-
+  coq.unify-eq {{ Num.RealField.unitRingType lp:F }} T ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Parse goal (and hypotheses) to extract a realFieldType or realDomainType
+% from (in)equalities it contains
+
+% field structure from a term of type bool
+pred fstr.bool i:term, o:term.
+fstr.bool {{ _ ==> lp:Type }} F :- fstr.bool Type F.
+fstr.bool {{ lp:Type ==> _ }} F :- fstr.bool Type F.
+fstr.bool {{ ~~ lp:Type }} F :- fstr.bool Type F.
+fstr.bool {{ _ && lp:Type }} F :- fstr.bool Type F.
+fstr.bool {{ lp:Type && _ }} F :- fstr.bool Type F.
+fstr.bool {{ _ || lp:Type }} F :- fstr.bool Type F.
+fstr.bool {{ lp:Type || _ }} F :- fstr.bool Type F.
+fstr.bool {{ @Order.le _ lp:Ty _ _ }} F :- f->porder F Ty.
+fstr.bool {{ @Order.lt _ lp:Ty _ _ }} F :- f->porder F Ty.
+
+% field structure from a term of type Prop
+pred fstr.prop i:term, o:term.
+fstr.prop {{ _ -> lp:Type }} F :- fstr.prop Type F.
+fstr.prop {{ lp:Type -> _ }} F :- fstr.prop Type F.
+fstr.prop {{ iff _ lp:Type }} F :- fstr.prop Type F.
+fstr.prop {{ iff lp:Type _ }} F :- fstr.prop Type F.
+fstr.prop {{ ~ lp:Type }} F :- fstr.prop Type F.
+fstr.prop {{ _ /\ lp:Type }} F :- fstr.prop Type F.
+fstr.prop {{ lp:Type /\ _ }} F :- fstr.prop Type F.
+fstr.prop {{ _ \/ lp:Type }} F :- fstr.prop Type F.
+fstr.prop {{ lp:Type \/ _ }} F :- fstr.prop Type F.
+fstr.prop {{ is_true lp:Type }} F :- fstr.bool Type F.
+fstr.prop {{ @eq bool _ lp:Type }} F :- fstr.bool Type F.
+fstr.prop {{ @eq bool lp:Type _ }} F :- fstr.bool Type F.
+fstr.prop {{ @eq lp:Ty _ _ }} F :- f->sort F Ty.
+
+pred fstr i:term, o:term.
+fstr Type F :- fstr.prop Type F.
+fstr _ _ :- coq.ltac.fail _ "Cannot find a realFieldType".
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Reification procedure
+
+% [quote.cst F In Out] reifies rational constants
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [F],
+% - [Out] is a reified constant of type [Q]
+pred quote.cst i:term, i:term, o:term.
+quote.cst F {{ GRing.zero lp:Z }} {{ Qmake 0 1 }} :- f->zmod F Z.
+quote.cst F {{ GRing.one lp:R }} {{ Qmake 1 1 }} :- f->ring F R.
+quote.cst F {{ @GRing.natmul lp:Z (GRing.one lp:R) lp:X }} {{ Qmake lp:XZ 1 }} :-
+  f->zmod F Z, f->ring F R, nat->Z X XZ.
+quote.cst F {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:R) lp:X) }}
+    E' :- f->unitRing F U, f->zmod F Z, f->ring F R,
+  nat->N X XN, XN = {{ Npos lp:XP }}, !, E' = {{ Qmake 1 lp:XP }}.
+
+% [quote.expr F In Out VarMap] reifies arithmetic expressions
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [F],
+% - [Out] is a reified expression of type [PExpr Q]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote.expr i:term, i:term, o:term, o:list term.
+quote.expr F {{ lp:X : _ }} X' VM :- !, quote.expr F X X' VM.
+quote.expr F {{ @GRing.add lp:Z lp:E1 lp:E2 }} E' VM :- f->zmod F Z, !,
+  quote.expr F E1 E1' VM, !, quote.expr F E2 E2' VM, !,
+  E' = {{ PEadd lp:E1' lp:E2' }}.
+quote.expr F {{ @GRing.opp lp:Z lp:E }} {{ PEopp lp:E' }} VM :- f->zmod F Z, !,
+  quote.expr F E E' VM.
+quote.expr F {{ @GRing.mul lp:R lp:E1 lp:E2 }} E' VM :- f->ring F R, !,
+  quote.expr F E1 E1' VM, !, quote.expr F E2 E2' VM, !,
+  E' = {{ PEmul lp:E1' lp:E2' }}.
+quote.expr F {{ @GRing.exp lp:R lp:E1 lp:X }} E' VM :-
+  f->ring F R, nat->N X XN, !,
+  quote.expr F E1 E1' VM, E' = {{ PEpow lp:E1' lp:XN }}.
+quote.expr F E {{ PEc lp:Q }} _ :- quote.cst F E Q.
+quote.expr _ X Out VarMap :- !, mem VarMap X N, Out = {{ PEX lp:N }}.
+
+% [quote.bop2 F In Out VarMap] reifies boolean (in)equalities
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [bool],
+% - [Out] is a reified expression of type [Formula Q]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote.bop2 i:term, i:term, o:term, o:list term.
+quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} F' VM :- f->porder F O, !,
+  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
+  F' = {{ Build_Formula lp:X' OpLe lp:Y' }}.
+quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} F' VM :- f->porder F O, !,
+  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
+  F' = {{ Build_Formula lp:X' OpLt lp:Y' }}.
+quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} F' VM :- f->eq F T, !,
+  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
+  F' = {{ Build_Formula lp:X' OpEq lp:Y' }}.
+
+% [quote.pop2 F In Out VarMap] reifies (in)equalities of type Prop
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [Prop],
+% - [Out] is a reified expression of type [Formula Q]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote.pop2 i:term, i:term, o:term, o:list term.
+quote.pop2 F {{ is_true lp:E }} F' VM :- quote.bop2 F E F' VM.
+quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} F' VM :- f->sort F T, !,
+  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
+  F' = {{ Build_Formula lp:X' OpEq lp:Y' }}.
+
+% [quote.bool F In Out VarMap] reifies boolean formulas
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [bool],
+% - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isBool]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote.bool i:term, i:term, o:term, o:list term.
+quote.bool F {{ lp:F1 ==> lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} VM :- !,
+  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
+quote.bool F {{ lp:F1 && lp:F2 }} {{ AND lp:F1' lp:F2' }} VM :- !,
+  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
+quote.bool F {{ lp:F1 || lp:F2 }} {{ OR lp:F1' lp:F2' }} VM :- !,
+  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
+quote.bool F {{ ~~ lp:F1 }} {{ NOT lp:F1' }} VM :- !, quote.bool F F1 F1' VM.
+quote.bool _ {{ true }} {{ TT Tauto.isBool }} _.
+quote.bool _ {{ false }} {{ FF Tauto.isBool }} _.
+quote.bool F A {{ A Tauto.isBool lp:A' tt }} VM :- quote.bop2 F A A' VM.
+quote.bool _ X {{ X Tauto.isBool lp:X }} _.
+
+% [quote.prop F In Out VarMap] reifies formulas of type Prop
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [Prop],
+% - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote.prop i:term, i:term, o:term, o:list term.
+quote.prop F {{ lp:F1 -> lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} VM :- !,
+  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
+quote.prop F {{ iff lp:F1 lp:F2 }} {{ IFF lp:F1' lp:F2' }} VM :- !,
+  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
+quote.prop F {{ lp:F1 /\ lp:F2 }} {{ AND lp:F1' lp:F2' }} VM :- !,
+  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
+quote.prop F {{ lp:F1 \/ lp:F2 }} {{ OR lp:F1' lp:F2' }} VM :- !,
+  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
+quote.prop F {{ ~ lp:F1 }} {{ NOT lp:F1' }} VM :- !, quote.prop F F1 F1' VM.
+quote.prop _ {{ True }} {{ TT Tauto.isProp }} _.
+quote.prop _ {{ False }} {{ FF Tauto.isProp }} _.
+quote.prop F {{ is_true lp:F1 }} {{ EQ lp:F1' (TT Tauto.isBool) }} VM :- !,
+  quote.bool F F1 F1' VM.
+quote.prop F {{ @eq bool lp:F1 lp:F2 }} {{ EQ lp:F1' lp:F2' }} VM :- !,
+  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
+quote.prop F A {{ A Tauto.isProp lp:A' tt }} VM :- quote.pop2 F A A' VM.
+quote.prop _ X {{ X Tauto.isProp lp:X }} _.
+
+% [simplify.bool In Out] reduces a boolean formula to [X _]
+% when it doesn't contain any arithmetic part
+% - [In] is a reified formula of type [BFormula (Formula Q) Tauto.isBool],
+% - [Out] is a simplified formula of type [BFormula (Formula Q) Tauto.isBool]
+pred simplify.bool i:term, o:term.
+simplify.bool {{ IMPL (X _ lp:F1) None (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isBool (lp:F1 ==> lp:F2) }}.
+simplify.bool {{ IMPL lp:F1 None lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} :-
+  simplify.bool F1 F1', simplify.bool F2 F2'.
+simplify.bool {{ AND (X _ lp:F1) (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isBool (lp:F1 && lp:F2) }}.
+simplify.bool {{ AND lp:F1 lp:F2 }} {{ AND lp:F1' lp:F2' }} :-
+  simplify.bool F1 F1', simplify.bool F2 F2'.
+simplify.bool {{ OR (X _ lp:F1) (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isBool (lp:F1 || lp:F2) }}.
+simplify.bool {{ OR lp:F1 lp:F2 }} {{ OR lp:F1' lp:F2' }} :-
+  simplify.bool F1 F1', simplify.bool F2 F2'.
+simplify.bool {{ NOT (X _ lp:F) }} {{ X Tauto.isProp (~~ lp:F) }}.
+simplify.bool {{ NOT lp:F }} {{ NOT lp:F' }} :- simplify.bool F F'.
+simplify.bool X X.
+
+% [simplify.prop In Out] reduces a formula to [X _]
+% when it doesn't contain any arithmetic part
+% - [In] is a reified formula of type [BFormula (Formula Q) Tauto.isProp],
+% - [Out] is a simplified formula of type [BFormula (Formula Q) Tauto.isProp]
+pred simplify.prop i:term, o:term.
+simplify.prop {{ IMPL (X _ lp:F1) None (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isProp (lp:F1 -> lp:F2) }}.
+simplify.prop {{ IMPL lp:F1 None lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} :-
+  simplify.prop F1 F1', simplify.prop F2 F2'.
+simplify.prop {{ IFF (X _ lp:F1) (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isProp (iff lp:F1 lp:F2) }}.
+simplify.prop {{ IFF lp:F1 lp:F2 }} {{ IFF lp:F1' lp:F2' }} :-
+  simplify.prop F1 F1', simplify.prop F2 F2'.
+simplify.prop {{ AND (X _ lp:F1) (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isProp (lp:F1 /\ lp:F2) }}.
+simplify.prop {{ AND lp:F1 lp:F2 }} {{ AND lp:F1' lp:F2' }} :-
+  simplify.prop F1 F1', simplify.prop F2 F2'.
+simplify.prop {{ OR (X _ lp:F1) (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isProp (lp:F1 \/ lp:F2) }}.
+simplify.prop {{ OR lp:F1 lp:F2 }} {{ OR lp:F1' lp:F2' }} :-
+  simplify.prop F1 F1', simplify.prop F2 F2'.
+simplify.prop {{ NOT (X _ lp:F) }} {{ X Tauto.isProp (~ lp:F) }}.
+simplify.prop {{ NOT lp:F }} {{ NOT lp:F' }} :- simplify.prop F F'.
+simplify.prop {{ EQ (X _ lp:F1) (X _ lp:F2) }} F' :-
+  F' = {{ X Tauto.isProp (lp:F1 = lp:F2) }}.
+simplify.prop {{ EQ lp:F1 lp:F2 }} {{ EQ lp:F1' lp:F2' }} :-
+  simplify.bool F1 F1', simplify.bool F2 F2'.
+simplify.prop X X.
+
+% [quote F In Out VarMap] reifies formulas of type Prop
+% - [F] is a [realFieldType] instance,
+% - [In] is a term of type [Prop],
+% - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote i:term, i:term, o:term, o:list term.
+quote F In Out' VM :- quote.prop F In Out VM, simplify.prop Out Out'.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Main tactic
+
+% This calls the Ltac1 tactic "lraF" with the following arguments:
+% - [TypeF'] the reified goal as a [BFormula (Formula Q) Tauto.isProp]
+% - [VM''] a variable map, giving the interpretation to variables in [TypeF']
+%   it is of type [VarMap.t F] where [F] is the carrier for the detected
+%   [realFieldType]
+solve (goal _Ctx _Trigger Type _Proof _Args as G) GL :-
+  fstr Type F, !,
+  quote F Type TypeF' VM, !,
+  std.assert-ok!
+    (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
+    "The reification produced an ill-typed result, this is a bug.",
+  f->sort F FS, list-constant FS VM VM',
+  coq.reduction.vm.norm
+    {{ Internals.vm_of_list lp:VM' }}
+    {{ VarMap.t lp:FS }}
+    VM'',
+  (coq.ltac.call "lraF" [trm TypeF', trm VM''] G GL;
+   coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -5,10 +5,38 @@ pred list-constant o:term, o:list term, o:term.
 list-constant T [] {{ @nil lp:T }} :- !.
 list-constant T [X|XS] {{ @cons lp:T lp:X lp:XS' }} :- list-constant T XS XS'.
 
-pred mem o:list term, o:term, o:term.
-mem [X|_] X {{ 1%positive }}.
-mem [_|XS] X M :- !, mem XS X N,
-  coq.reduction.vm.norm {{ Pos.succ lp:N }} {{ positive }} M.
+pred mem o:list term, o:term, o:int.
+mem [X|_] X 0 :- !.
+mem [_|XS] X M :- !, mem XS X N, M is N + 1.
+
+pred eucldiv o:int, i:int, o:int, i:int.
+eucldiv N D M R :- var N, var M, !, declare_constraint (eucldiv N D M R) [N, M].
+eucldiv N D M R :- var N, N is D * M + R.
+eucldiv N D M R :- var M, M is N div D, R is N mod D.
+
+pred positive-constant o:int, o:term.
+positive-constant 1 {{ lib:num.pos.xH }} :- !.
+positive-constant N {{ lib:num.pos.xO lp:T }} :-
+  eucldiv N 2 M 0, positive-constant M T.
+positive-constant N {{ lib:num.pos.xI lp:T }} :-
+  eucldiv N 2 M 1, positive-constant M T.
+
+pred n-constant o:int, o:term.
+n-constant N _ :- not (var N), N < 0, !, fail.
+n-constant 0 {{ lib:num.N.N0 }} :- !.
+n-constant N {{ lib:num.N.Npos lp:T }} :- !, positive-constant N T.
+
+pred z-constant o:int, o:term.
+z-constant 0 {{ lib:num.Z.Z0 }} :- !.
+z-constant N T :-
+  var T, N < 0, !,
+  T = {{ lib:num.Z.Zneg lp:T' }}, positive-constant {calc (~ N)} T'.
+z-constant N T :-
+  var T, 0 < N, !, T = {{ lib:num.Z.Zpos lp:T' }}, positive-constant N T'.
+z-constant N {{ lib:num.Z.Zneg lp:T }} :-
+  var N, !, positive-constant N' T, N is ~ N'.
+z-constant N {{ lib:num.Z.Zpos lp:T }} :-
+  var N, !, positive-constant N T.
 
 pred ground-pos i:term.
 ground-pos {{ xH }}.
@@ -24,6 +52,9 @@ ground-Z {{ Z0 }}.
 ground-Z {{ Zpos lp:P }} :- !, ground-pos P.
 ground-Z {{ Zneg lp:P }} :- !, ground-pos P.
 
+pred reduction-pos i:term, o:term.
+reduction-pos I O :- coq.reduction.vm.norm I {{ positive }} O, ground-pos O.
+
 pred reduction-N i:term, o:term.
 reduction-N I O :- coq.reduction.vm.norm I {{ N }} O, ground-N O.
 
@@ -31,421 +62,437 @@ pred reduction-Z i:term, o:term.
 reduction-Z I O :- coq.reduction.vm.norm I {{ Z }} O, ground-Z O.
 
 pred nat->N i:term, o:term.
-nat->N {{ Init.Nat.of_num_uint lp:X }} XN :-
+nat->N {{ Init.Nat.of_num_uint lp:X }} XN :- !,
   reduction-N {{ N.of_num_uint lp:X }} XN.
-nat->N {{ lp:X }} XN :- reduction-N {{ N.of_nat lp:X }} XN.
+nat->N X XN :- !, reduction-N {{ N.of_nat lp:X }} XN.
 
 pred nat->Z i:term, o:term.
-nat->Z {{ Init.Nat.of_num_uint lp:X }} XZ :-
+nat->Z {{ Init.Nat.of_num_uint lp:X }} XZ :- !,
   reduction-Z {{ Z.of_num_uint lp:X }} XZ.
-nat->Z {{ lp:X }} XZ :- reduction-Z {{ Z.of_nat lp:X }} XZ.
+nat->Z X XZ :- !, reduction-Z {{ Z.of_nat lp:X }} XZ.
+
+pred nat->NZ i:term, o:term, o:term.
+nat->NZ {{ Init.Nat.of_num_uint lp:X }} XN XZ :- !,
+  reduction-N {{ N.of_num_uint lp:X }} XN, reduction-Z {{ Z.of_N lp:XN }} XZ.
+nat->NZ X XN XZ :- !,
+  reduction-N {{ N.of_nat lp:X }} XN, reduction-Z {{ Z.of_N lp:XN }} XZ.
+
+pred int->Z i:term, o:term.
+int->Z X XZ :- !, reduction-Z {{ Z_of_int lp:X }} XZ.
+
+pred negb i:bool, o:bool.
+negb tt ff :- !.
+negb ff tt :- !.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Sum type to contain either realDomainType or realFieldType
-% and casts from both to various substructures
-
-% ring or field
-kind rf type.
-type ring term -> rf.
-type field term -> rf.
-
-pred rf->sort o:rf, o:term.
-rf->sort (field F) T :- coq.unify-eq {{ Num.RealField.sort lp:F }} T ok.
-rf->sort (ring R) T :- coq.unify-eq {{ Num.RealDomain.sort lp:R }} T ok.
-
-pred rf->eq o:rf, o:term.
-rf->eq (field F) T :- coq.unify-eq {{ Num.RealField.eqType lp:F }} T ok.
-rf->eq (ring R) T :- coq.unify-eq {{ Num.RealDomain.eqType lp:R }} T ok.
-
-pred rf->porder o:rf, o:term.
-rf->porder (field F) T :- coq.unify-eq {{ Num.RealField.porderType lp:F }} T ok.
-rf->porder (ring R) T :- coq.unify-eq {{ Num.RealDomain.porderType lp:R }} T ok.
-
-pred rf->ring o:rf, o:term.
-rf->ring (field F) T :- coq.unify-eq {{ Num.RealField.ringType lp:F }} T ok.
-rf->ring (ring R) T :- coq.unify-eq {{ Num.RealDomain.ringType lp:R }} T ok.
-
-pred rf->numDomain o:rf, o:term.
-rf->numDomain (field F) D :-
-  coq.unify-eq {{ Num.RealField.numDomainType lp:F }} D ok.
-rf->numDomain (ring R) D :-
-  coq.unify-eq {{ Num.RealDomain.numDomainType lp:R }} D ok.
-
-pred field->unitRing o:term, o:term.
-field->unitRing F U :- coq.unify-eq {{ GRing.Field.unitRingType lp:F }} U ok.
-
-pred unitRing->ring o:term, o:term.
-unitRing->ring U R :- coq.unify-eq {{ GRing.UnitRing.ringType lp:U }} R ok.
-
-pred ring->zmod o:term, o:term.
-ring->zmod R T :- coq.unify-eq {{ GRing.Ring.zmodType lp:R }} T ok.
-
 % [field-mode] is true if we are on a realFieldType,
 % otherwise we are on a realDomainType.
 pred field-mode.
+
+% Type to contain the carrier type and the following structure instances
+% attached to it: realFieldType (optional), realDomainType,
+% fieldType (optional), unitRingType (optional), ringType, porderType, eqType,
+% Type
+kind carrier type.
+type carrier option term -> term -> option term -> option term -> term ->
+             term -> term -> Type -> carrier.
+
+pred type->carrier i:term, o:carrier, o:prop.
+type->carrier Ty (carrier (some RF) RD (some F) (some UR) R PO EQ Ty)
+              field-mode :-
+  std.do! [ coq.unify-eq Ty {{ Num.RealField.sort lp:RF }} ok,
+            coq.unify-eq Ty {{ Num.RealDomain.sort lp:RD }} ok,
+            coq.unify-eq Ty {{ GRing.Field.sort lp:F }} ok,
+            coq.unify-eq Ty {{ GRing.UnitRing.sort lp:UR }} ok,
+            coq.unify-eq Ty {{ GRing.Ring.sort lp:R }} ok,
+            coq.unify-eq Ty {{ @Order.POrder.sort _ lp:PO }} ok,
+            coq.unify-eq Ty {{ Equality.sort lp:EQ }} ok ].
+type->carrier Ty (carrier none RD none none R PO EQ Ty) true :-
+  std.do! [ coq.unify-eq Ty {{ Num.RealDomain.sort lp:RD }} ok,
+            coq.unify-eq Ty {{ GRing.Ring.sort lp:R }} ok,
+            coq.unify-eq Ty {{ @Order.POrder.sort _ lp:PO }} ok,
+            coq.unify-eq Ty {{ Equality.sort lp:EQ }} ok ].
+
+pred carrier->realField i:carrier, o:term.
+carrier->realField (carrier (some RF) _ _ _ _ _ _ _) RF :- !.
+
+pred carrier->realDomain i:carrier, o:term.
+carrier->realDomain (carrier _ RD _ _ _ _ _ _) RD :- !.
+
+pred carrier->field i:carrier, o:term.
+carrier->field (carrier _ _ (some F) _ _ _ _ _) F :- !.
+
+pred carrier->unitRing i:carrier, o:term.
+carrier->unitRing (carrier _ _ _ (some UR) _ _ _ _) UR :- !.
+
+pred carrier->ring i:carrier, o:term.
+carrier->ring (carrier _ _ _ _ R _ _ _) R :- !.
+
+pred carrier->porder i:carrier, o:term.
+carrier->porder (carrier _ _ _ _ _ PO _ _) PO :- !.
+
+pred carrier->eq i:carrier, o:term.
+carrier->eq (carrier _ _ _ _ _ _ EQ _) EQ :- !.
+
+pred carrier->type i:carrier, o:term.
+carrier->type (carrier _ _ _ _ _ _ _ Ty) Ty :- !.
+
+pred field->unitRing o:term, o:term.
+field->unitRing F U :- !, coq.unify-eq {{ GRing.Field.unitRingType lp:F }} U ok.
+
+pred unitRing->ring o:term, o:term.
+unitRing->ring U R :- !, coq.unify-eq {{ GRing.UnitRing.ringType lp:U }} R ok.
+
+pred ring->zmod o:term, o:term.
+ring->zmod R T :- !, coq.unify-eq {{ GRing.Ring.zmodType lp:R }} T ok.
+
+% [ring->field Ring Field]: [Field] is optionally a [fieldType] instance such
+% that [GRing.Field.ringType Field = Ring].
+pred ring->field i:term, o:option term.
+ring->field R (some F) :-
+  field-mode,
+  coq.unify-eq {{ GRing.Ring.sort lp:R }} {{ GRing.Field.sort lp:F }} ok, !.
+ring->field _ none.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Parse goal (and hypotheses) to extract a realFieldType or realDomainType
 % from (in)equalities it contains
 
-% ring or field structure from a term of type bool
-pred rfstr.bool i:term, o:rf.
-rfstr.bool {{ _ ==> lp:Type }} F :- rfstr.bool Type F.
-rfstr.bool {{ lp:Type ==> _ }} F :- rfstr.bool Type F.
-rfstr.bool {{ ~~ lp:Type }} F :- rfstr.bool Type F.
-rfstr.bool {{ _ && lp:Type }} F :- rfstr.bool Type F.
-rfstr.bool {{ lp:Type && _ }} F :- rfstr.bool Type F.
-rfstr.bool {{ _ || lp:Type }} F :- rfstr.bool Type F.
-rfstr.bool {{ lp:Type || _ }} F :- rfstr.bool Type F.
-rfstr.bool {{ @Order.le _ lp:Ty _ _ }} F :- field-mode,
-  rf->porder F Ty, F = field _.
-rfstr.bool {{ @Order.lt _ lp:Ty _ _ }} F :- field-mode,
-  rf->porder F Ty, F = field _.
-rfstr.bool {{ @Order.le _ lp:Ty _ _ }} R :- not field-mode,
-  rf->porder R Ty, R = ring _.
-rfstr.bool {{ @Order.lt _ lp:Ty _ _ }} R :- not field-mode,
-  rf->porder R Ty, R = ring _.
+% carrier type from a term of type bool
+pred rfstr.bool i:term, o:carrier, o:prop.
+rfstr.bool {{ lp:Ty1 ==> lp:Ty2 }} C IsField :- !,
+  (rfstr.bool Ty2 C IsField; rfstr.bool Ty1 C IsField).
+rfstr.bool {{ ~~ lp:Ty }} C IsField :- !, rfstr.bool Ty C IsField.
+rfstr.bool {{ lp:Ty1 && lp:Ty2 }} C IsField :- !,
+  (rfstr.bool Ty2 C IsField; rfstr.bool Ty1 C IsField).
+rfstr.bool {{ lp:Ty1 || lp:Ty2 }} C IsField :- !,
+  (rfstr.bool Ty2 C IsField; rfstr.bool Ty1 C IsField).
+rfstr.bool {{ @Order.le _ lp:Ty _ _ }} C IsField :- !,
+  type->carrier {{ @Order.POrder.sort _ lp:Ty }} C IsField.
+rfstr.bool {{ @Order.lt _ lp:Ty _ _ }} C IsField :- !,
+  type->carrier {{ @Order.POrder.sort _ lp:Ty }} C IsField.
 
-% ring or field structure from a term of type Prop
-pred rfstr.prop i:term, o:rf.
-rfstr.prop {{ _ -> lp:Type }} F :- rfstr.prop Type F.
-rfstr.prop {{ lp:Type -> _ }} F :- rfstr.prop Type F.
-rfstr.prop {{ iff _ lp:Type }} F :- rfstr.prop Type F.
-rfstr.prop {{ iff lp:Type _ }} F :- rfstr.prop Type F.
-rfstr.prop {{ ~ lp:Type }} F :- rfstr.prop Type F.
-rfstr.prop {{ _ /\ lp:Type }} F :- rfstr.prop Type F.
-rfstr.prop {{ lp:Type /\ _ }} F :- rfstr.prop Type F.
-rfstr.prop {{ _ \/ lp:Type }} F :- rfstr.prop Type F.
-rfstr.prop {{ lp:Type \/ _ }} F :- rfstr.prop Type F.
-rfstr.prop {{ is_true lp:Type }} F :- rfstr.bool Type F.
-rfstr.prop {{ @eq bool _ lp:Type }} F :- rfstr.bool Type F.
-rfstr.prop {{ @eq bool lp:Type _ }} F :- rfstr.bool Type F.
-rfstr.prop {{ @eq lp:Ty _ _ }} F :- field-mode, rf->sort F Ty, F = field _.
-rfstr.prop {{ @eq lp:Ty _ _ }} R :- not field-mode, rf->sort R Ty, R = ring _.
+% carrier type from a term of type Prop
+pred rfstr.prop i:term, o:carrier, o:prop.
+rfstr.prop {{ lp:Ty1 -> lp:Ty2 }} C IsField :- !,
+  (rfstr.prop Ty2 C IsField; rfstr.prop Ty1 C IsField).
+rfstr.prop {{ iff lp:Ty1 lp:Ty2 }} C IsField :- !,
+  (rfstr.prop Ty2 C IsField; rfstr.prop Ty1 C IsField).
+rfstr.prop {{ ~ lp:Type }} C IsField :- rfstr.prop Type C IsField.
+rfstr.prop {{ lp:Ty1 /\ lp:Ty2 }} C IsField :- !,
+  (rfstr.prop Ty2 C IsField; rfstr.prop Ty1 C IsField).
+rfstr.prop {{ lp:Ty1 \/ lp:Ty2 }} C IsField :- !,
+  (rfstr.prop Ty2 C IsField; rfstr.prop Ty1 C IsField).
+rfstr.prop {{ is_true lp:Ty }} C IsField :- !, rfstr.bool Ty C IsField.
+rfstr.prop {{ @eq lp:Bool lp:Ty1 lp:Ty2 }} C IsField :-
+  coq.unify-eq Bool {{ bool }} ok, !,
+  (rfstr.bool Ty2 C IsField; rfstr.bool Ty1 C IsField).
+rfstr.prop {{ @eq lp:Ty _ _ }} C IsField :- !, type->carrier Ty C IsField.
 
-pred rfstr.hyps i:list prop, o:rf.
-rfstr.hyps [decl _ _ H|_] F :- rfstr.prop H F.
-rfstr.hyps [_|Ctx] F :- rfstr.hyps Ctx F.
+pred rfstr.hyps i:list prop, o:carrier, o:prop.
+rfstr.hyps [decl _ _ H|_] C IsField :- rfstr.prop H C IsField.
+rfstr.hyps [_|Ctx] C IsField :- rfstr.hyps Ctx C IsField.
 
-pred rfstr i:list prop, i:term, o:rf.
-rfstr _ Type F :- field-mode => rfstr.prop Type F.
-rfstr _ Type R :- rfstr.prop Type R.
-rfstr Ctx _ F :- field-mode => rfstr.hyps Ctx F.
-rfstr Ctx _ R :- rfstr.hyps Ctx R.
-rfstr _ _ _ :- coq.ltac.fail _ "Cannot find a realDomainType".
+pred rfstr i:list prop, i:term, o:carrier, o:prop.
+rfstr _ Type C IsField :- rfstr.prop Type C IsField, !.
+rfstr Ctx _ C IsField :- rfstr.hyps Ctx C IsField, !.
+rfstr _ _ _ _ :- coq.ltac.fail _ "Cannot find a realDomainType".
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Reification procedure
 
-% [quote.cstr V In OutM Out] reifies integer constants
-% - [V] is a [ringType]
-% - [In] is a term of type [V],
-% - [OutM] is a reified constant of type [MExpr V]
-% - [Out] is a reified constant of type [PExpr Q]
-% - [OutQ] the reified [Out] as a [Q] (for <= 8.15 compat)
-pred quote.cstr i:term, i:term, o:term, o:term, o:term.
-quote.cstr V {{ GRing.zero lp:Z }} OutM Out OutQ :- ring->zmod V Z,
-  OutM = {{ @Internals.MEint lp:V Z0 }}, Out = {{ PEc (Qmake Z0 1) }},
-  OutQ = {{ Qmake Z0 1 }}.
-quote.cstr V {{ GRing.one lp:V' }} OutM Out OutQ :- coq.unify-eq V V' ok,
-  OutM = {{ @Internals.MEint lp:V (Zpos 1) }}, Out = {{ PEc (Qmake 1 1) }},
-  OutQ = {{ Qmake 1 1 }}.
-quote.cstr V {{ @GRing.natmul lp:Z (GRing.one lp:V') lp:X }} OutM Out OutQ :-
-  ring->zmod V Z, coq.unify-eq V V' ok, nat->Z X XZ,
-  OutM = {{ @Internals.MEint lp:V lp:XZ }}, Out = {{ PEc (Qmake lp:XZ 1) }},
-  OutQ = {{ Qmake lp:XZ 1 }}.
+% [quote.cstr Inv In OutM Out] reifies integer constants
+% - [Inv] is a Boolean flag indicating that [Out] should represent the
+%   multiplicative inverse of [In],
+% - [In] is an input term of type [int] or [Z],
+% - [OutM] is a reified constant of type [RExpr V],
+% - [Out] is a reified constant of type [Q]
+pred quote.cstr i:bool, i:term, o:term, o:term.
+quote.cstr ff {{ Posz lp:N }} {{ RintC lp:Z }} {{ Qmake lp:Z 1 }} :- !,
+  nat->Z N Z.
+quote.cstr tt {{ Posz lp:N }} {{ RintC lp:Z }} Out :- !,
+  nat->Z N Z, !,
+  if (Z = {{ Zpos lp:P }}) (Out = {{ Qmake 1 lp:P }}) (Out = {{ Qmake 0 1 }}).
+quote.cstr ff {{ Negz lp:N }} {{ RintC lp:Z }} {{ Qmake lp:Z 1 }} :- !,
+  int->Z {{ Negz lp:N }} Z.
+quote.cstr tt {{ Negz lp:N }} {{ RintC lp:Z }} {{ Qmake -1 lp:P }} :- !,
+  int->Z {{ Negz lp:N }} Z, !, Z = {{ Zneg lp:P }}.
+quote.cstr _ {{ Z0 }} {{ RZC Z0 }} {{ Qmake 0 1 }} :- !.
+quote.cstr ff {{ Zpos lp:P }} {{ RZC (Zpos lp:P') }}
+           {{ Qmake (Zpos lp:P') 1 }} :- !,
+  reduction-pos P P'.
+quote.cstr tt {{ Zpos lp:P }} {{ RZC (Zpos lp:P') }} {{ Qmake 1 lp:P' }} :- !,
+  reduction-pos P P'.
+quote.cstr ff {{ Zneg lp:P }} {{ RZC (Zneg lp:P') }}
+           {{ Qmake (Zneg lp:P') 1 }} :- !,
+  reduction-pos P P'.
+quote.cstr tt {{ Zneg lp:P }} {{ RZC (Zneg lp:P') }} {{ Qmake -1 lp:P' }} :- !,
+  reduction-pos P P'.
 
-% [quote.cstf V In OutM Out] reifies rational constants
-% - [V] is a [ringType] instance,
-% - [In] is a term of type [V],
-% - [OutM] is a reified constant of type [MExpr V]
-% - [Out] is a reified constant of type [PExpr Q]
-% - [OutQ] the reified [Out] as a [Q] (for <= 8.15 compat)
-pred quote.cstf i:term, i:term, o:term, o:term, o:term.
-quote.cstf V {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:V') lp:X) }}
-    OutM Out XQ :- unitRing->ring U V, ring->zmod V Z, coq.unify-eq V V' ok,
-  nat->N X XN, XN = {{ Npos lp:XP }}, XQ = {{ Qmake 1 lp:XP }},
-  field->unitRing F U,
-  OutM = {{ @Internals.MErat lp:F lp:XQ }}, Out = {{ PEc lp:XQ }}.
+% [quote.expr Inv R F TR Morph In OutM Out VM] reifies arithmetic expressions
+% - [Inv] is a Boolean flag indicating that [Out] should represent the
+%   multiplicative inverse of [In],
+% - [R] is a [ringType] instance,
+% - [F] is optionally a [fieldType] instance such that
+%   [GRing.Field.ringType F = R],
+% - [TR] is optionally an [unitRingType] instance,
+% - [Morph] is a function from [R] to [TR],
+% - [In] is a term of type [R],
+% - [OutM] is a reified expression of type [RExpr R],
+% - [Out] is a reified expression of type [PExpr Q], and
+% - [VM] is a variable map, that is a list of terms of type [R].
+pred quote.expr i:bool, i:term, i:option term, i:option term,
+    i:(term -> term), i:term, o:term, o:term, o:list term.
+% 0%R
+quote.expr _ R _ _ _ {{ @GRing.zero lp:V }}
+           {{ @R0 lp:R }} {{ PEc (Qmake 0 1) }} _ :-
+  ring->zmod R V,
+  !.
+% -%R
+quote.expr Inv R F TR Morph {{ @GRing.opp lp:V lp:In }}
+           {{ @ROpp lp:R lp:OutM }} {{ PEopp lp:Out }} VM :-
+  ring->zmod R V,
+  !,
+  quote.expr Inv R F TR Morph In OutM Out VM.
+% +%R
+quote.expr ff R F TR Morph {{ @GRing.add lp:V lp:In1 lp:In2 }}
+           {{ @RAdd lp:R lp:OutM1 lp:OutM2 }} {{ PEadd lp:Out1 lp:Out2 }} VM :-
+  ring->zmod R V,
+  !,
+  quote.expr ff R F TR Morph In1 OutM1 Out1 VM, !,
+  quote.expr ff R F TR Morph In2 OutM2 Out2 VM.
+% (_ *+ _)%R
+quote.expr Inv R F TR Morph {{ @GRing.natmul lp:V lp:In1 lp:X }}
+           {{ @RMuln lp:R lp:OutM1 lp:XN }}
+           {{ PEmul lp:Out1 (PEc lp:Out2) }} VM :-
+  ring->zmod R V, nat->NZ X XN XZ,
+  !,
+  quote.expr Inv R F TR Morph In1 OutM1 Out1 VM, !,
+  if (Inv = ff) (Out2 = {{ Qmake lp:XZ 1 }})
+     (if (XZ = {{ Zpos lp:XP }})
+         (Out2 = {{ Qmake 1 lp:XP }}) (Out2 = {{ Qmake 0 1 }})).
+% (_ *~ _)%R
+quote.expr Inv R F TR Morph {{ @intmul lp:V lp:In1 lp:In2 }}
+           {{ @RMulz lp:R lp:OutM1 lp:OutM2 }} {{ PEmul lp:Out1 lp:Out2 }} VM :-
+  ring->zmod R V,
+  !,
+  quote.expr Inv R F TR Morph In1 OutM1 Out1 VM, !,
+  quote.expr Inv R F TR Morph In2 OutM2 Out2 VM.
+% 1%R
+quote.expr _ R _ _ _ {{ @GRing.one lp:R' }}
+           {{ @R1 lp:R }} {{ PEc (Qmake 1 1) }} _ :-
+  coq.unify-eq R R' ok, !.
+% *%R
+quote.expr Inv R F TR Morph {{ @GRing.mul lp:R' lp:In1 lp:In2 }}
+           {{ @RMul lp:R lp:OutM1 lp:OutM2 }} {{ PEmul lp:Out1 lp:Out2 }} VM :-
+  coq.unify-eq R R' ok,
+  !,
+  quote.expr Inv R F TR Morph In1 OutM1 Out1 VM, !,
+  quote.expr Inv R F TR Morph In2 OutM2 Out2 VM.
+% (_ ^+ _)%R
+quote.expr Inv R F TR Morph {{ @GRing.exp lp:R' lp:In lp:X }}
+           {{ @RExpn lp:R lp:OutM lp:XN }} {{ PEpow lp:Out lp:XN }} VM :-
+  coq.unify-eq R R' ok, nat->N X XN,
+  !,
+  quote.expr Inv R F TR Morph In OutM Out VM.
+% _^-1
+quote.expr Inv R (some F) TR Morph {{ @GRing.inv lp:R' lp:In }}
+           {{ @RInv lp:F lp:OutM }} Out VM :-
+  field-mode,
+  field->unitRing F R',
+  !,
+  quote.expr { negb Inv } R (some F) TR Morph In OutM Out VM.
+% morphisms
+quote.expr Inv R _ TR Morph In
+           {{ @RMorph lp:R' lp:R lp:NewMorphInst lp:OutM }} Out VM :-
+  NewMorph = (x\ {{ @GRing.RMorphism.apply
+                      lp:R' lp:R _ lp:NewMorphInst lp:x }}),
+  coq.unify-eq In (NewMorph In1) ok,
+  !,
+  quote.expr Inv R' { ring->field R' } TR (x\ Morph (NewMorph x)) In1
+    OutM Out VM.
+% int and Z constants
+quote.expr Inv _ _ _ _ In OutM {{ PEc lp:Out }} _ :-
+  quote.cstr Inv In OutM Out, !.
+% variables
+quote.expr Inv R _ TR Morph In {{ @RX lp:R lp:In }} {{ PEX lp:P }} VM :- !,
+  MIn = Morph In, !,
+  if (Inv = tt)
+     (TR = some TR', mem VM {{ @GRing.inv lp:TR' lp:MIn }} N) (mem VM MIn N), !,
+  positive-constant { calc (N + 1) } P.
 
-% [quote.expr V F In OutM Out VM] reifies arithmetic expressions
-% - [V] is a [ringType]
-% - [F] is a function
-% - [In] is a term of type [V],
-% - [OutM] is a reified expression of type [MExpr V]
-% - [Out] is a reified expression of type [PExpr Q]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [V].
-pred quote.expr i:term, i:(term -> term), i:term,
-    o:term, o:term, o:term, o:list term.
-quote.expr V F {{ @GRing.add lp:Z lp:In1 lp:In2 }} OutM Out OutQ VM :-
-  ring->zmod V Z, !,
-  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
-  quote.expr V F In2 OutM2 Out2 OutQ2 VM, !,
-  OutM = {{ @Internals.MEadd lp:V lp:OutM1 lp:OutM2 }},
-  Out = {{ PEadd lp:Out1 lp:Out2 }},
-  OutQ = {{ (lp:OutQ1 + lp:OutQ2)%Q }}.
-quote.expr V F {{ @GRing.mul lp:V' lp:In1 lp:In2 }} OutM Out OutQ VM :-
-  coq.unify-eq V V' ok, !,
-  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
-  quote.expr V F In2 OutM2 Out2 OutQ2 VM, !,
-  OutM = {{ @Internals.MEmul lp:V lp:OutM1 lp:OutM2 }},
-  Out = {{ PEmul lp:Out1 lp:Out2 }},
-  OutQ = {{ (lp:OutQ1 * lp:OutQ2)%Q }}.
-quote.expr V F {{ @GRing.opp lp:Z lp:In1 }} OutM Out OutQ VM :-
-  ring->zmod V Z, !,
-  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
-  OutM = {{ @Internals.MEopp lp:V lp:OutM1 }}, Out = {{ PEopp lp:Out1 }},
-  OutQ = {{ (- lp:OutQ1)%Q }}.
-quote.expr V F {{ @GRing.exp lp:V' lp:In1 lp:X }} OutM Out OutQ VM :-
-  coq.unify-eq V V' ok, nat->N X XN, !,
-  quote.expr V F In1 OutM1 Out1 OutQ1 VM, !,
-  OutM = {{ @Internals.MEpow lp:V lp:OutM1 lp:XN }},
-  Out = {{ PEpow lp:Out1 lp:XN }},
-  nat->Z X XZ, OutQ = {{ (lp:OutQ1 ^ lp:XZ)%Q }}.
-quote.expr V _ In OutM Out OutQ _ :- quote.cstr V In OutM Out OutQ.
-quote.expr V _ In OutM Out OutQ _ :- field-mode, quote.cstf V In OutM Out OutQ.
-quote.expr V F In {{ @Internals.MEmorph lp:U lp:V lp:G lp:OutM }} Out OutQ VM :-
-  coq.unify-eq
-    {{ @GRing.RMorphism.apply lp:U lp:V lp:Ph lp:G lp:In1 }} In ok, !,
-  quote.expr U (x\ F {{ @GRing.RMorphism.apply lp:U lp:V lp:Ph lp:G lp:x }})
-    In1 OutM Out OutQ VM.
-quote.expr V F In {{ @Internals.MEX lp:V lp:In }} {{ PEX lp:N }} OutQ VM :- !,
-  FIn = F In,
-  mem VM FIn N,
-  OutQ = {{ @Internals.R2Q lp:V lp:FIn }}.
+% [quote.exprw C In OutM Out VM] reifies arithmetic expressions
+% - [C] is the carrier type and structure instances,
+% - [In] is a term of type [C],
+% - [OutM] is a reified expression of type [RExpr C],
+% - [Out] is a reified expression of type [PExpr Q], and
+pred quote.exprw i:carrier, i:term, o:term, o:term, o:list term.
+quote.exprw (carrier _ _ F TR R _ _ _) In OutM Out VM :-
+  quote.expr ff R F TR (x\ x) In OutM Out VM.
 
-% [quote.exprw F In OutM Out VM] reifies arithmetic expressions
-% - [F] is a [realDomainType] or [realFieldType] instance,
-% - [In] is a term of type [F],
-% - [OutM] is a reified expression of type [MExpr F]
-% - [Out] is a reified expression of type [PExpr Q]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.exprw i:rf, i:term, o:term, o:term, o:term, o:list term.
-quote.exprw F In OutM Out OutQ VM :- F = field _, !,
-  field-mode => quote.expr { rf->ring F } (x\ x) In OutM Out OutQ VM.
-quote.exprw F In OutM Out OutQ VM :- F = ring _, !,
-  quote.expr { rf->ring F } (x\ x) In OutM Out OutQ VM.
-
-% [quote.bop2 F In OutM Out VM] reifies boolean (in)equalities
-% - [F] is a [realDomainType] or [realFieldType] instance,
+% [quote.bop2 C In OutM Out VM] reifies boolean (in)equalities
+% - [C] is the carrier type and structure instances,
 % - [In] is a term of type [bool],
-% - [OutM] is a reified expression of type [MFormula]
-% - [Out] is a reified expression of type [Formula Q]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.bop2 i:rf, i:term, o:term, o:term, o:term, o:list term.
-quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} OutM Out OutQ VM :-
-  rf->porder F O, !,
-  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
-  OutM = {{ Internals.Build_MFormula lp:XM' OpLe lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpLe lp:Y' }},
-  OutQ = {{ (lp:XQ' <= lp:YQ')%Q }}.
-quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} OutM Out OutQ VM :-
-  rf->porder F O, !,
-  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
-  OutM = {{ Internals.Build_MFormula lp:XM' OpLt lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpLt lp:Y' }},
-  OutQ = {{ (lp:XQ' < lp:YQ')%Q }}.
-quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} OutM Out OutQ VM :-
-  rf->eq F T, !,
-  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
-  OutM = {{ Internals.Build_MFormula lp:XM' OpEq lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpEq lp:Y' }},
-  OutQ = {{ (lp:XQ' == lp:YQ')%Q }}.
+% - [OutM] is a reified expression of type [RFormula C],
+% - [Out] is a reified expression of type [Formula Q], and
+% - [VM] is a variable map, that is a list of terms of type [C].
+pred quote.bop2 i:carrier, i:term, o:term, o:term, o:list term.
+quote.bop2 C {{ @Order.le _ lp:O lp:X lp:Y }}
+           {{ Build_RFormula lp:XM' OpLe lp:YM' }}
+           {{ Build_Formula lp:X' OpLe lp:Y' }} VM :-
+  coq.unify-eq { carrier->porder C } O ok, !,
+  quote.exprw C X XM' X' VM, !, quote.exprw C Y YM' Y' VM.
+quote.bop2 C {{ @Order.lt _ lp:O lp:X lp:Y }}
+           {{ Build_RFormula lp:XM' OpLt lp:YM' }}
+           {{ Build_Formula lp:X' OpLt lp:Y' }} VM :-
+  coq.unify-eq { carrier->porder C } O ok, !,
+  quote.exprw C X XM' X' VM, !, quote.exprw C Y YM' Y' VM.
+quote.bop2 C {{ @eq_op lp:T lp:X lp:Y }}
+           {{ Build_RFormula lp:XM' OpEq lp:YM' }}
+           {{ Build_Formula lp:X' OpEq lp:Y' }} VM :-
+  coq.unify-eq { carrier->eq C } T ok, !,
+  quote.exprw C X XM' X' VM, !, quote.exprw C Y YM' Y' VM.
 
-% [quote.pop2 F In OutM Out VM] reifies (in)equalities of type Prop
-% - [F] is a [realDomainType] or [realFieldType] instance,
+% [quote.pop2 C In OutM Out VM] reifies (in)equalities of type Prop
+% - [C] is the carrier type and structure instances,
 % - [In] is a term of type [Prop],
-% - [OutM] is a reified expression of type [MFormula]
-% - [Out] is a reified expression of type [Formula Q]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.pop2 i:rf, i:term, o:term, o:term, o:term, o:list term.
-quote.pop2 F {{ is_true lp:E }} OutM Out OutQ VM :-
-  quote.bop2 F E OutM Out OutQ VM.
-quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} OutM Out OutQ VM :- rf->sort F T, !,
-  quote.exprw F X XM' X' XQ' VM, !, quote.exprw F Y YM' Y' YQ' VM, !,
-  OutM = {{ Internals.Build_MFormula lp:XM' OpEq lp:YM' }},
-  Out = {{ Build_Formula lp:X' OpEq lp:Y' }},
-  OutQ = {{ (lp:XQ' == lp:YQ')%Q }}.
+% - [OutM] is a reified expression of type [RFormula C],
+% - [Out] is a reified expression of type [Formula Q], and
+% - [VM] is a variable map, that is a list of terms of type [C].
+pred quote.pop2 i:carrier, i:term, o:term, o:term, o:list term.
+quote.pop2 C {{ is_true lp:E }} OutM Out VM :- quote.bop2 C E OutM Out VM.
+quote.pop2 C {{ @eq lp:T lp:X lp:Y }}
+           {{ Build_RFormula lp:XM' OpEq lp:YM' }}
+           {{ Build_Formula lp:X' OpEq lp:Y' }} VM :-
+  coq.unify-eq {carrier->type C} T ok, !,
+  quote.exprw C X XM' X' VM, !, quote.exprw C Y YM' Y' VM.
 
-% [quote.bool F In OutM Out VM] reifies boolean formulas
-% - [F] is a [realDomainType] or [realFieldType] instance,
+% GFormula constructors
+pred build.implb i:term, i:term, o:term.
+build.implb {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+            {{ X isBool (lp:In1 ==> lp:In2) }} :- !.
+build.implb In1 In2 {{ IMPL lp:In1 None lp:In2 }} :- !.
+
+pred build.andb i:term, i:term, o:term.
+build.andb {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+           {{ X isBool (lp:In1 && lp:In2) }} :- !.
+build.andb In1 In2 {{ AND lp:In1 lp:In2 }} :- !.
+
+pred build.orb i:term, i:term, o:term.
+build.orb {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+          {{ X isBool (lp:In1 || lp:In2) }} :- !.
+build.orb In1 In2 {{ OR lp:In1 lp:In2 }} :- !.
+
+pred build.negb i:term, o:term.
+build.negb {{ X _ lp:In1 }} {{ X isBool (~~ lp:In1) }} :- !.
+build.negb In {{ NOT lp:In }} :- !.
+
+pred build.implp i:term, i:term, o:term.
+build.implp {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+            {{ X isProp (lp:In1 -> lp:In2) }} :- !.
+build.implp In1 In2 {{ IMPL lp:In1 None lp:In2 }} :- !.
+
+pred build.iffp i:term, i:term, o:term.
+build.iffp {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+            {{ X isProp (iff lp:In1 lp:In2) }} :- !.
+build.iffp In1 In2 {{ IFF lp:In1 lp:In2 }} :- !.
+
+pred build.andp i:term, i:term, o:term.
+build.andp {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+           {{ X isProp (lp:In1 /\ lp:In2) }} :- !.
+build.andp In1 In2 {{ AND lp:In1 lp:In2 }} :- !.
+
+pred build.orp i:term, i:term, o:term.
+build.orp {{ X _ lp:In1 }} {{ X _ lp:In2 }}
+          {{ X isProp (lp:In1 \/ lp:In2) }} :- !.
+build.orp In1 In2 {{ OR lp:In1 lp:In2 }} :- !.
+
+pred build.negp i:term, o:term.
+build.negp {{ X _ lp:In1 }} {{ X isProp (~ lp:In1) }} :- !.
+build.negp In {{ NOT lp:In }} :- !.
+
+% [quote.bool C In OutM Out VM] reifies boolean formulas
+% - [C] is the carrier type and structure instances,
 % - [In] is a term of type [bool],
-% - [OutM] is a reified formula of type [BFormula MFormula Tauto.isBool]
-% - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isBool]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.bool i:rf, i:term, o:term, o:term, o:term, o:list term.
-quote.bool F {{ lp:F1 ==> lp:F2 }} OutM Out OutQ VM :- !,
-  quote.bool F F1 OutM1 Out1 OutQ1 VM, !, quote.bool F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ IMPL lp:OutM1 None lp:OutM2 }},
-  Out = {{ IMPL lp:Out1 None lp:Out2 }},
-  OutQ = {{ lp:OutQ1 -> lp:OutQ2 }}.
-quote.bool F {{ lp:F1 && lp:F2 }} OutM Out OutQ VM :- !,
-  quote.bool F F1 OutM1 Out1 OutQ1 VM, !, quote.bool F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }},
-  OutQ = {{ lp:OutQ1 /\ lp:OutQ2 }}.
-quote.bool F {{ lp:F1 || lp:F2 }} OutM Out OutQ VM :- !,
-  quote.bool F F1 OutM1 Out1 OutQ1 VM, !, quote.bool F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }},
-  OutQ = {{ lp:OutQ1 \/ lp:OutQ2 }}.
-quote.bool F {{ ~~ lp:F1 }} OutM Out OutQ VM :- !,
-  quote.bool F F1 OutM1 Out1 OutQ1 VM, !,
-  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}, OutQ = {{ ~ lp:OutQ1 }}.
-quote.bool _ {{ true }} OutM Out OutQ _ :- !,
-  OutM = {{ TT Tauto.isBool }}, Out = {{ TT Tauto.isBool }}, OutQ = {{ True }}.
-quote.bool _ {{ false }} OutM Out OutQ _ :- !,
-  OutM = {{ FF Tauto.isBool }}, Out = {{ FF Tauto.isBool }}, OutQ = {{ False }}.
-quote.bool F In OutM Out OutQ VM :- quote.bop2 F In OutM' Out' OutQ VM,
-  OutM = {{ A Tauto.isBool lp:OutM' tt }},
-  Out = {{ A Tauto.isBool lp:Out' tt }}.
-quote.bool _ In OutM Out In _ :-
-  OutM = {{ X Tauto.isBool lp:In }}, Out = {{ X Tauto.isBool lp:In }}.
+% - [OutM] is a reified formula of type [BFormula (RFormula C) isBool],
+% - [Out] is a reified formula of type [BFormula (Formula Q) isBool], and
+% - [VM] is a variable map, that is a list of terms of type [C].
+pred quote.bool i:carrier, i:term, o:term, o:term, o:list term.
+quote.bool C {{ lp:In1 ==> lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.bool C In1 OutM1 Out1 VM, quote.bool C In2 OutM2 Out2 VM,
+   build.implb OutM1 OutM2 OutM, build.implb Out1 Out2 Out].
+quote.bool C {{ lp:In1 && lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.bool C In1 OutM1 Out1 VM, quote.bool C In2 OutM2 Out2 VM,
+   build.andb OutM1 OutM2 OutM, build.andb Out1 Out2 Out].
+quote.bool C {{ lp:In1 || lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.bool C In1 OutM1 Out1 VM, quote.bool C In2 OutM2 Out2 VM,
+   build.orb OutM1 OutM2 OutM, build.orb Out1 Out2 Out].
+quote.bool C {{ ~~ lp:In1 }} OutM Out VM :- !, std.do!
+  [quote.bool C In1 OutM1 Out1 VM, build.negb OutM1 OutM, build.negb Out1 Out].
+quote.bool _ {{ true }} {{ TT isBool }} {{ TT isBool }} _ :- !.
+quote.bool _ {{ false }} {{ FF isBool }} {{ FF isBool }} _ :- !.
+quote.bool C In {{ A isBool lp:OutM tt }} {{ A isBool lp:Out tt }} VM :-
+  quote.bop2 C In OutM Out VM.
+quote.bool _ In {{ X isBool lp:In }} {{ X isBool lp:In }} _ :- !.
 
-% [quote.prop F In OutM Out VM] reifies formulas of type Prop
-% - [F] is a [realDomainType] or [realFieldType] instance,
+% [quote.prop C In OutM Out VM] reifies formulas of type Prop
+% - [C] is the carrier type and structure instances,
 % - [In] is a term of type [Prop],
-% - [OutM] is a reified formula of type [BFormula MFormula Tauto.isProp]
-% - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.prop i:rf, i:term, o:term, o:term, o:term, o:list term.
-quote.prop F {{ lp:F1 -> lp:F2 }} OutM Out OutQ VM :- !,
-  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ IMPL lp:OutM1 None lp:OutM2 }},
-  Out = {{ IMPL lp:Out1 None lp:Out2 }},
-  OutQ = {{ lp:OutQ1 -> lp:OutQ2 }}.
-quote.prop F {{ iff lp:F1 lp:F2 }} OutM Out OutQ VM :- !,
-  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ IFF lp:OutM1 lp:OutM2 }}, Out = {{ IFF lp:Out1 lp:Out2 }},
-  OutQ = {{ iff lp:OutQ1 lp:OutQ2 }}.
-quote.prop F {{ lp:F1 /\ lp:F2 }} OutM Out OutQ VM :- !,
-  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }},
-  OutQ = {{ lp:OutQ1 /\ lp:OutQ2 }}.
-quote.prop F {{ lp:F1 \/ lp:F2 }} OutM Out OutQ VM :- !,
-  quote.prop F F1 OutM1 Out1 OutQ1 VM, !, quote.prop F F2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }},
-  OutQ = {{ lp:OutQ1 \/ lp:OutQ2 }}.
-quote.prop F {{ ~ lp:F1 }} OutM Out OutQ VM :- !,
-  quote.prop F F1 OutM1 Out1 OutQ1 VM, !,
-  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}, OutQ = {{ ~ lp:OutQ1 }}.
-quote.prop _ {{ True }} OutM Out OutQ _ :- !,
-  OutM = {{ TT Tauto.isProp }}, Out = {{ TT Tauto.isProp }}, OutQ = {{ True }}.
-quote.prop _ {{ False }} OutM Out OutQ _ :- !,
-  OutM = {{ FF Tauto.isProp }}, Out = {{ FF Tauto.isProp }}, OutQ = {{ False }}.
-quote.prop F {{ is_true lp:In1 }} OutM Out OutQ VM :- !,
-  quote.bool F In1 OutM1 Out1 OutQ1 VM, !,
-  OutM = {{ EQ lp:OutM1 (TT Tauto.isBool) }},
-  Out = {{ EQ lp:Out1 (TT Tauto.isBool) }},
-  OutQ = {{ lp:OutQ1 }}.
-quote.prop F {{ @eq bool lp:In1 lp:In2 }} OutM Out OutQ VM :- !,
-  quote.bool F In1 OutM1 Out1 OutQ1 VM, !, quote.bool F In2 OutM2 Out2 OutQ2 VM,
-  OutM = {{ EQ lp:OutM1 lp:OutM2 }}, Out = {{ EQ lp:Out1 lp:Out2 }},
-  OutQ = {{ lp:OutQ1 <-> lp:OutQ2 }}.
-quote.prop F In OutM Out OutQ VM :- quote.pop2 F In OutM' Out' OutQ VM,
-  OutM = {{ A Tauto.isProp lp:OutM' tt }},
-  Out = {{ A Tauto.isProp lp:Out' tt }}.
-quote.prop _ In OutM Out In _ :-
-  OutM = {{ X Tauto.isProp lp:In }}, Out = {{ X Tauto.isProp lp:In }}.
+% - [OutM] is a reified formula of type [BFormula (RFormula C) isProp],
+% - [Out] is a reified formula of type [BFormula (Formula Q) isProp], and
+% - [VM] is a variable map, that is a list of terms of type [C].
+pred quote.prop i:carrier, i:term, o:term, o:term, o:list term.
+quote.prop C {{ lp:In1 -> lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.prop C In1 OutM1 Out1 VM, quote.prop C In2 OutM2 Out2 VM,
+   build.implp OutM1 OutM2 OutM, build.implp Out1 Out2 Out].
+quote.prop C {{ iff lp:In1 lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.prop C In1 OutM1 Out1 VM, quote.prop C In2 OutM2 Out2 VM,
+   build.iffp OutM1 OutM2 OutM, build.iffp Out1 Out2 Out].
+quote.prop C {{ lp:In1 /\ lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.prop C In1 OutM1 Out1 VM, quote.prop C In2 OutM2 Out2 VM,
+   build.andp OutM1 OutM2 OutM, build.andp Out1 Out2 Out].
+quote.prop C {{ lp:In1 \/ lp:In2 }} OutM Out VM :- !, std.do!
+  [quote.prop C In1 OutM1 Out1 VM, quote.prop C In2 OutM2 Out2 VM,
+   build.orb OutM1 OutM2 OutM, build.orb Out1 Out2 Out].
+quote.prop C {{ ~ lp:In1 }} OutM Out VM :- !, std.do!
+  [quote.prop C In1 OutM1 Out1 VM, build.negp OutM1 OutM, build.negp Out1 Out].
+quote.prop _ {{ True }} {{ TT isProp }} {{ TT isProp }} _ :- !.
+quote.prop _ {{ False }} {{ FF isProp }} {{ FF isProp }} _ :- !.
+quote.prop C {{ is_true lp:In1 }}
+           {{ EQ lp:OutM1 (TT isBool) }} {{ EQ lp:Out1 (TT isBool) }} VM :- !,
+  quote.bool C In1 OutM1 Out1 VM, !.
+quote.prop C {{ @eq lp:Bool lp:In1 lp:In2 }} OutM Out VM :-
+  coq.unify-eq Bool {{ bool }} ok, !,
+  quote.bool C In1 OutM1 Out1 VM, !, quote.bool C In2 OutM2 Out2 VM, !,
+  OutM = {{ EQ lp:OutM1 lp:OutM2 }}, !, Out = {{ EQ lp:Out1 lp:Out2 }}.
+quote.prop C In {{ A isProp lp:OutM tt }} {{ A isProp lp:Out tt }} VM :-
+  quote.pop2 C In OutM Out VM.
+quote.prop _ In {{ X isProp lp:In }} {{ X isProp lp:In }} _ :- !.
 
-% [simplify.bool In Out] reduces a boolean formula to [X _]
-% when it doesn't contain any arithmetic part
-% - [In] is a reified formula of type [BFormula _ Tauto.isBool],
-% - [Out] is a simplified formula of type [BFormula _ Tauto.isBool]
-pred simplify.bool i:term, o:term.
-simplify.bool {{ IMPL (X _ lp:F1) None (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isBool (lp:F1 ==> lp:F2) }}.
-simplify.bool {{ IMPL lp:F1 None lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} :-
-  simplify.bool F1 F1', simplify.bool F2 F2'.
-simplify.bool {{ AND (X _ lp:F1) (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isBool (lp:F1 && lp:F2) }}.
-simplify.bool {{ AND lp:F1 lp:F2 }} {{ AND lp:F1' lp:F2' }} :-
-  simplify.bool F1 F1', simplify.bool F2 F2'.
-simplify.bool {{ OR (X _ lp:F1) (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isBool (lp:F1 || lp:F2) }}.
-simplify.bool {{ OR lp:F1 lp:F2 }} {{ OR lp:F1' lp:F2' }} :-
-  simplify.bool F1 F1', simplify.bool F2 F2'.
-simplify.bool {{ NOT (X _ lp:F) }} {{ X Tauto.isProp (~~ lp:F) }}.
-simplify.bool {{ NOT lp:F }} {{ NOT lp:F' }} :- simplify.bool F F'.
-simplify.bool X X.
-
-% [simplify.prop In Out] reduces a formula to [X _]
-% when it doesn't contain any arithmetic part
-% - [In] is a reified formula of type [BFormula _ Tauto.isProp],
-% - [Out] is a simplified formula of type [BFormula _ Tauto.isProp]
-pred simplify.prop i:term, o:term.
-simplify.prop {{ IMPL (X _ lp:F1) None (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isProp (lp:F1 -> lp:F2) }}.
-simplify.prop {{ IMPL lp:F1 None lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} :-
-  simplify.prop F1 F1', simplify.prop F2 F2'.
-simplify.prop {{ IFF (X _ lp:F1) (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isProp (iff lp:F1 lp:F2) }}.
-simplify.prop {{ IFF lp:F1 lp:F2 }} {{ IFF lp:F1' lp:F2' }} :-
-  simplify.prop F1 F1', simplify.prop F2 F2'.
-simplify.prop {{ AND (X _ lp:F1) (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isProp (lp:F1 /\ lp:F2) }}.
-simplify.prop {{ AND lp:F1 lp:F2 }} {{ AND lp:F1' lp:F2' }} :-
-  simplify.prop F1 F1', simplify.prop F2 F2'.
-simplify.prop {{ OR (X _ lp:F1) (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isProp (lp:F1 \/ lp:F2) }}.
-simplify.prop {{ OR lp:F1 lp:F2 }} {{ OR lp:F1' lp:F2' }} :-
-  simplify.prop F1 F1', simplify.prop F2 F2'.
-simplify.prop {{ NOT (X _ lp:F) }} {{ X Tauto.isProp (~ lp:F) }}.
-simplify.prop {{ NOT lp:F }} {{ NOT lp:F' }} :- simplify.prop F F'.
-simplify.prop {{ EQ (X _ lp:F1) (X _ lp:F2) }} F' :-
-  F' = {{ X Tauto.isProp (lp:F1 = lp:F2) }}.
-simplify.prop {{ EQ lp:F1 lp:F2 }} {{ EQ lp:F1' lp:F2' }} :-
-  simplify.bool F1 F1', simplify.bool F2 F2'.
-simplify.prop X X.
-
-% [quote F In Out VM] reifies formulas of type Prop
-% - [F] is a [realDomainType] or [realFieldType] instance,
-% - [In] is a term of type [Prop],
-% - [OutM] is a reified formula of type [BFormula MFormula Tauto.isProp]
-% - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
-% - [OutQ] the reified [Out] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote i:rf, i:term, o:term, o:term, o:term, o:list term.
-quote F In OutM' Out' OutQ VM :-
-  quote.prop F In OutM Out OutQ VM,
-  simplify.prop OutM OutM', simplify.prop Out Out'.
-
-% [quote.hyps F Hyps Goal ReifiedGoal Out ReifiedOut VM] reifies hypotheses
-% - [F] is a [realDomainType] or [realFieldType] instance,
-% - [Hyps] are hypotheses
-% - [Goal] is the goal, of type [Prop]
-% - [ReifiedGoalM] is the refied goal as a [BFormula MFormula Tauto.isProp]
-% - [ReifiedGoal] is the refied goal as a [BFormula (Formula Q) Tauto.isProp]
-% - [ReifiedGoalQ] the reified goal as a [Prop] about [Q] (for <= 8.15 compat)
+% [quote.goal C Hyps Goal Out ReifiedOutM ReifiedOut VM] reifies the goal
+% - [C] is the carrier type and structure instances,
+% - [Hyps] are hypotheses,
+% - [Goal] is the goal, of type [Prop],
 % - [Out] is a chain of implications including [Goal] and hypotheses in [Hyps]
-%   that have some arithmetic content
-% - [ReifiedOutM] is a reified version of [Out]
-%   as a [BFormula MFormula Tauto.isProp]
-% - [ReifiedOut] is a reified version of [Out]
-%   as a [BFormula (Formula Q) Tauto.isProp]
-% - [ReifiedOutQ] the [ReifiedOut] as a [Prop] about [Q] (for <= 8.15 compat)
-% - [VM] is a variable map, that is a list of terms of type [F].
-pred quote.hyps i:rf, i:list prop, i:term, i:term, i:term, i:term,
-  o:term, o:term, o:term, o:term, o:list term.
-quote.hyps F [decl _ _ H|Ctx] Type TypeFM TypeF TypeFQ
-    Type'' TypeFM'' TypeF'' TypeFQ'' VM :-
-  quote F H HM' H' HQ' VM, not (H' = {{ X _ _ }}), !,
-  quote.hyps F Ctx Type TypeFM TypeF TypeFQ Type' TypeFM' TypeF' TypeFQ' VM,
-  Type'' = {{ lp:H -> lp:Type' }},
-  TypeFM'' = {{ IMPL lp:HM' None lp:TypeFM' }},
-  TypeF'' = {{ IMPL lp:H' None lp:TypeF' }},
-  TypeFQ'' = {{ lp:HQ' -> lp:TypeFQ' }}.
-quote.hyps F [decl _ _ _|Ctx] Type TypeFM TypeF TypeFQ
-    Type' TypeFM' TypeF' TypeFQ' VM :- !,
-  quote.hyps F Ctx Type TypeFM TypeF TypeFQ Type' TypeFM' TypeF' TypeFQ' VM.
-quote.hyps F [def _ _ _ _|Ctx] Type TypeFM TypeF TypeFQ
-    Type' TypeFM' TypeF' TypeFQ' VM :- !,
-  quote.hyps F Ctx Type TypeFM TypeF TypeFQ Type' TypeFM' TypeF' TypeFQ' VM.
-quote.hyps _ [] Type TypeFM TypeF TypeFQ Type TypeFM TypeF TypeFQ _.
+%   that have some arithmetic content,
+% - [ReifiedOutM] is a reified version of [Out] as a
+%   [BFormula (RFormula C) isProp],
+% - [ReifiedOut] is a reified version of [Out] as a
+%   [BFormula (Formula Q) isProp], and
+% - [VM] is a variable map, that is a list of terms of type [C].
+pred quote.goal i:carrier, i:list prop, i:term,
+  o:term, o:term, o:term, o:list term.
+quote.goal C [decl _ _ H|Ctx] Type
+           {{ lp:H -> lp:Type' }} {{ IMPL lp:HM' None lp:TypeFM' }}
+           {{ IMPL lp:H' None lp:TypeF' }} VM :-
+  quote.prop C H HM' H' VM, not (H' = {{ X _ _ }}), !,
+  quote.goal C Ctx Type Type' TypeFM' TypeF' VM.
+quote.goal C [decl _ _ _|Ctx] Type Type' TypeFM' TypeF' VM :- !,
+  quote.goal C Ctx Type Type' TypeFM' TypeF' VM.
+quote.goal C [def _ _ _ _|Ctx] Type Type' TypeFM' TypeF' VM :- !,
+  quote.goal C Ctx Type Type' TypeFM' TypeF' VM.
+quote.goal C [] Type Type TypeFM TypeF VM :- !,
+  quote.prop C Type TypeFM TypeF VM.
 
 % [exfalso_if_not_prop In Out Bool] changes [In] to [False]
 % when [In] is not a [Prop] (and then set [Bool] to [true])
@@ -466,33 +513,27 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 % - [Efalso] a term of type [bool] indicating if the goal was changed to [False]
 % - [Type''] a term of type [Prop], an implication with the goal
 %   and selected hypotheses
-% - [TypeFM'] the reified [Type''] as a [BFormula MFormula Tauto.isProp]
-% - [TypeF'] the reified [Type''] as a [BFormula (Formula Q) Tauto.isProp]
+% - [TypeFM'] the reified [Type''] as a [BFormula RFormula isProp]
+% - [TypeF'] the reified [Type''] as a [BFormula (Formula Q) isProp]
 % - [TypeFQ'] the reified [Type''] as a [Prop] about [Q] (for <= 8.15 compat)
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
 %   [realFieldType] or [realDomainType]
-solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :-
-  exfalso_if_not_prop Type Type' Efalso,
-  std.rev Ctx Ctx', !,
-  rfstr Ctx' Type' F, !,
-  quote F Type' TypeFM TypeF TypeFQ VM, !,
-  quote.hyps F Ctx' Type' TypeFM TypeF TypeFQ Type'' TypeFM' TypeF' TypeFQ' VM,
-  !,
-  rf->numDomain F NDF,
-  std.assert-ok!
-    (coq.typecheck TypeFM' {{ BFormula (@Internals.MFormula lp:NDF) isProp }})
-    "The reification produced an ill-typed result, this is a bug.",
-  std.assert-ok!
-    (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
-    "The reification produced an ill-typed result, this is a bug.",
-  rf->sort F FS, list-constant FS VM VM',
-  coq.reduction.vm.norm
-    {{ Internals.vm_of_list lp:VM' }}
-    {{ VarMap.t lp:FS }}
-    VM'',
-  (if (F = field _) (Tac = TacF) (Tac = TacR)),
-  (coq.ltac.call
-     Tac [N, trm Efalso, trm Type'', trm TypeFM', trm TypeF', trm TypeFQ',
-          trm VM''] G GL;
-   coq.ltac.fail 0).
+solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :- std.do!
+  [ exfalso_if_not_prop Type Type' Efalso,
+    std.rev Ctx Ctx',
+    rfstr Ctx' Type' C IsField,
+    (IsField => quote.goal C Ctx' Type' Type'' TypeFM' TypeF' VM),
+    carrier->ring C R,
+    std.assert-ok!
+      (coq.typecheck TypeFM' {{ BFormula (@RFormula lp:R) isProp }})
+      "The reification produced an ill-typed result, this is a bug.",
+    std.assert-ok!
+      (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
+      "The reification produced an ill-typed result, this is a bug.",
+    list-constant { carrier->type C } VM VM',
+    if (C = carrier (some _) _ (some _) (some _) _ _ _ _)
+       (Tac = TacF) (Tac = TacR),
+    (coq.ltac.call
+       Tac [N, trm Efalso, trm Type'', trm TypeFM', trm TypeF', trm VM'] G GL;
+     coq.ltac.fail 0) ].

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -285,21 +285,30 @@ quote.hyps F [def _ _ _ _|Ctx] Type TypeF Type' TypeF' VM :- !,
   quote.hyps F Ctx Type TypeF Type' TypeF' VM.
 quote.hyps _ [] Type TypeF Type TypeF _.
 
+% [exfalso_if_not_prop In Out Bool] changes [In] to [False]
+% when [In] is not a [Prop] (and then set [Bool] to [true])
+pred exfalso_if_not_prop i:term, o:term, o:term.
+exfalso_if_not_prop Type Type {{ false }} :-
+  coq.typecheck Type {{ Prop }} ok.
+exfalso_if_not_prop _ {{ False }} {{ true }}.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Main tactic
 
 % This calls the Ltac1 tactic "lraF" with the following arguments:
-% - [Type'] a term of type [Prop], an implication with the goal
+% - [Efalso] a term of type [bool] indicating if the goal was changed to [False]
+% - [Type''] a term of type [Prop], an implication with the goal
 %   and selected hypotheses
-% - [TypeF'] the reified [Type'] as a [BFormula (Formula Q) Tauto.isProp]
+% - [TypeF'] the reified [Type''] as a [BFormula (Formula Q) Tauto.isProp]
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
 %   [realFieldType]
 solve (goal Ctx _Trigger Type _Proof _Args as G) GL :-
+  exfalso_if_not_prop Type Type' Efalso,
   std.rev Ctx Ctx', !,
-  fstr Ctx' Type F, !,
-  quote F Type TypeF VM, !,
-  quote.hyps F Ctx' Type TypeF Type' TypeF' VM, !,
+  fstr Ctx' Type' F, !,
+  quote F Type' TypeF VM, !,
+  quote.hyps F Ctx' Type' TypeF Type'' TypeF' VM, !,
   std.assert-ok!
     (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
     "The reification produced an ill-typed result, this is a bug.",
@@ -308,5 +317,5 @@ solve (goal Ctx _Trigger Type _Proof _Args as G) GL :-
     {{ Internals.vm_of_list lp:VM' }}
     {{ VarMap.t lp:FS }}
     VM'',
-  (coq.ltac.call "lraF" [trm Type', trm TypeF', trm VM''] G GL;
+  (coq.ltac.call "lraF" [trm Efalso, trm Type'', trm TypeF', trm VM''] G GL;
    coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -61,19 +61,24 @@ pred rf->porder o:rf, o:term.
 rf->porder (field F) T :- coq.unify-eq {{ Num.RealField.porderType lp:F }} T ok.
 rf->porder (ring R) T :- coq.unify-eq {{ Num.RealDomain.porderType lp:R }} T ok.
 
-pred rf->zmod o:rf, o:term.
-rf->zmod (field F) T :- coq.unify-eq {{ Num.RealField.zmodType lp:F }} T ok.
-rf->zmod (ring R) T :- coq.unify-eq {{ Num.RealDomain.zmodType lp:R }} T ok.
-
 pred rf->ring o:rf, o:term.
 rf->ring (field F) T :- coq.unify-eq {{ Num.RealField.ringType lp:F }} T ok.
 rf->ring (ring R) T :- coq.unify-eq {{ Num.RealDomain.ringType lp:R }} T ok.
 
-pred rf->unitRing o:rf, o:term.
-rf->unitRing (field F) T :-
-  coq.unify-eq {{ Num.RealField.unitRingType lp:F }} T ok.
-rf->unitRing (ring R) T :-
-  coq.unify-eq {{ Num.RealDomain.unitRingType lp:R }} T ok.
+pred rf->numDomain o:rf, o:term.
+rf->numDomain (field F) D :-
+  coq.unify-eq {{ Num.RealField.numDomainType lp:F }} D ok.
+rf->numDomain (ring R) D :-
+  coq.unify-eq {{ Num.RealDomain.numDomainType lp:R }} D ok.
+
+pred field->unitRing o:term, o:term.
+field->unitRing F U :- coq.unify-eq {{ GRing.Field.unitRingType lp:F }} U ok.
+
+pred unitRing->ring o:term, o:term.
+unitRing->ring U R :- coq.unify-eq {{ GRing.UnitRing.ringType lp:U }} R ok.
+
+pred ring->zmod o:term, o:term.
+ring->zmod R T :- coq.unify-eq {{ GRing.Ring.zmodType lp:R }} T ok.
 
 % [field-mode] is true if we are on a realFieldType,
 % otherwise we are on a realDomainType.
@@ -132,120 +137,186 @@ rfstr _ _ _ :- coq.ltac.fail _ "Cannot find a realDomainType".
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Reification procedure
 
-% [quote.cstr F In Out] reifies integer constants
-% - [F] is a [realDomainType] or [realFieldType] instance,
-% - [In] is a term of type [F],
-% - [Out] is a reified constant of type [Z]
-pred quote.cstr i:rf, i:term, o:term.
-quote.cstr F {{ GRing.zero lp:Z }} {{ Z0 }} :- rf->zmod F Z.
-quote.cstr F {{ GRing.one lp:R }} {{ (Zpos 1) }} :- rf->ring F R.
-quote.cstr F {{ @GRing.natmul lp:Z (GRing.one lp:R) lp:X }} XZ :-
-  rf->zmod F Z, rf->ring F R, nat->Z X XZ.
+% [quote.cstr V In OutM Out] reifies integer constants
+% - [V] is a [ringType]
+% - [In] is a term of type [V],
+% - [OutM] is a reified constant of type [MExpr V]
+% - [Out] is a reified constant of type [PExpr Q]
+pred quote.cstr i:term, i:term, o:term, o:term.
+quote.cstr V {{ GRing.zero lp:Z }} OutM Out :- ring->zmod V Z,
+  OutM = {{ @Internals.MEint lp:V Z0 }}, Out = {{ PEc (Qmake Z0 1) }}.
+quote.cstr V {{ GRing.one lp:V' }} OutM Out :- coq.unify-eq V V' ok,
+  OutM = {{ @Internals.MEint lp:V (Zpos 1) }}, Out = {{ PEc (Qmake 1 1) }}.
+quote.cstr V {{ @GRing.natmul lp:Z (GRing.one lp:V') lp:X }} OutM Out :-
+  ring->zmod V Z, coq.unify-eq V V' ok, nat->Z X XZ,
+  OutM = {{ @Internals.MEint lp:V lp:XZ }}, Out = {{ PEc (Qmake lp:XZ 1) }}.
 
-% [quote.cstf F In Out] reifies rational constants
-% - [F] is a [realFieldType] instance,
-% - [In] is a term of type [F],
-% - [Out] is a reified constant of type [Q]
-pred quote.cstf i:rf, i:term, o:term.
-quote.cstf F {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:R) lp:X) }}
-    E' :- rf->unitRing F U, rf->zmod F Z, rf->ring F R,
-  nat->N X XN, XN = {{ Npos lp:XP }}, !, E' = {{ Qmake 1 lp:XP }}.
+% [quote.cstf V In OutM Out] reifies rational constants
+% - [V] is a [ringType] instance,
+% - [In] is a term of type [V],
+% - [OutM] is a reified constant of type [MExpr V]
+% - [Out] is a reified constant of type [PExpr Q]
+pred quote.cstf i:term, i:term, o:term, o:term.
+quote.cstf V {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:V') lp:X) }}
+    OutM Out :- unitRing->ring U V, ring->zmod V Z, coq.unify-eq V V' ok,
+  nat->N X XN, XN = {{ Npos lp:XP }}, XQ = {{ Qmake 1 lp:XP }},
+  field->unitRing F U,
+  OutM = {{ @Internals.MErat lp:F lp:XQ }}, Out = {{ PEc lp:XQ }}.
 
-% [quote.expr F In Out VarMap] reifies arithmetic expressions
-% - [F] is a [realDomainType] or [realFieldType] instance,
-% - [In] is a term of type [F],
+% [quote.expr V F In OutM Out VM] reifies arithmetic expressions
+% - [V] is a [ringType]
+% - [F] is a function
+% - [In] is a term of type [V],
+% - [OutM] is a reified expression of type [MExpr V]
 % - [Out] is a reified expression of type [PExpr Q]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.expr i:rf, i:term, o:term, o:list term.
-quote.expr F {{ @GRing.add lp:Z lp:E1 lp:E2 }} E' VM :- rf->zmod F Z, !,
-  quote.expr F E1 E1' VM, !, quote.expr F E2 E2' VM, !,
-  E' = {{ PEadd lp:E1' lp:E2' }}.
-quote.expr F {{ @GRing.opp lp:Z lp:E }} {{ PEopp lp:E' }} VM :- rf->zmod F Z, !,
-  quote.expr F E E' VM.
-quote.expr F {{ @GRing.mul lp:R lp:E1 lp:E2 }} E' VM :- rf->ring F R, !,
-  quote.expr F E1 E1' VM, !, quote.expr F E2 E2' VM, !,
-  E' = {{ PEmul lp:E1' lp:E2' }}.
-quote.expr F {{ @GRing.exp lp:R lp:E1 lp:X }} E' VM :-
-  rf->ring F R, nat->N X XN, !,
-  quote.expr F E1 E1' VM, E' = {{ PEpow lp:E1' lp:XN }}.
-quote.expr F E {{ PEc (Qmake lp:Z 1) }} _ :- quote.cstr F E Z.
-quote.expr F E {{ PEc lp:Q }} _ :- F = field _, quote.cstf F E Q.
-quote.expr F {{ lp:X : _ }} X' VM :- !, quote.expr F X X' VM.
-quote.expr _ X Out VarMap :- !, mem VarMap X N, Out = {{ PEX lp:N }}.
+% - [VM] is a variable map, that is a list of terms of type [V].
+pred quote.expr i:term, i:(term -> term), i:term, o:term, o:term, o:list term.
+quote.expr V F {{ @GRing.add lp:Z lp:In1 lp:In2 }} OutM Out VM :-
+  ring->zmod V Z, !,
+  quote.expr V F In1 OutM1 Out1 VM, !, quote.expr V F In2 OutM2 Out2 VM, !,
+  OutM = {{ @Internals.MEadd lp:V lp:OutM1 lp:OutM2 }},
+  Out = {{ PEadd lp:Out1 lp:Out2 }}.
+quote.expr V F {{ @GRing.mul lp:V' lp:In1 lp:In2 }} OutM Out VM :-
+  coq.unify-eq V V' ok, !,
+  quote.expr V F In1 OutM1 Out1 VM, !, quote.expr V F In2 OutM2 Out2 VM, !,
+  OutM = {{ @Internals.MEmul lp:V lp:OutM1 lp:OutM2 }},
+  Out = {{ PEmul lp:Out1 lp:Out2 }}.
+quote.expr V F {{ @GRing.opp lp:Z lp:In1 }} OutM Out VM :-
+  ring->zmod V Z, !,
+  quote.expr V F In1 OutM1 Out1 VM, !,
+  OutM = {{ @Internals.MEopp lp:V lp:OutM1 }}, Out = {{ PEopp lp:Out1 }}.
+quote.expr V F {{ @GRing.exp lp:V' lp:In1 lp:X }} OutM Out VM :-
+  coq.unify-eq V V' ok, nat->N X XN, !,
+  quote.expr V F In1 OutM1 Out1 VM, !,
+  OutM = {{ @Internals.MEpow lp:V lp:OutM1 lp:XN }},
+  Out = {{ PEpow lp:Out1 lp:XN }}.
+quote.expr V _ In OutM Out _ :- quote.cstr V In OutM Out.
+quote.expr V _ In OutM Out _ :- field-mode, quote.cstf V In OutM Out.
+quote.expr V F In {{ @Internals.MEmorph lp:U lp:V lp:G lp:OutM }} Out VM :-
+  coq.unify-eq
+    {{ @GRing.RMorphism.apply lp:U lp:V lp:Ph lp:G lp:In1 }} In ok, !,
+  quote.expr U (x\ F {{ @GRing.RMorphism.apply lp:U lp:V lp:Ph lp:G lp:x }})
+    In1 OutM Out VM.
+quote.expr V F In {{ @Internals.MEX lp:V lp:In }} {{ PEX lp:N }} VM :- !,
+  mem VM (F In) N.
 
-% [quote.bop2 F In Out VarMap] reifies boolean (in)equalities
+% [quote.exprw F In OutM Out VM] reifies arithmetic expressions
+% - [F] is a [realDomainType] or [realFieldType] instance,
+% - [In] is a term of type [F],
+% - [OutM] is a reified expression of type [MExpr F]
+% - [Out] is a reified expression of type [PExpr Q]
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote.exprw i:rf, i:term, o:term, o:term, o:list term.
+quote.exprw F In OutM Out VM :- F = field _, !,
+  field-mode => quote.expr { rf->ring F } (x\ x) In OutM Out VM.
+quote.exprw F In OutM Out VM :- F = ring _, !,
+  quote.expr { rf->ring F } (x\ x) In OutM Out VM.
+
+% [quote.bop2 F In OutM Out VM] reifies boolean (in)equalities
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [bool],
+% - [OutM] is a reified expression of type [MFormula]
 % - [Out] is a reified expression of type [Formula Q]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.bop2 i:rf, i:term, o:term, o:list term.
-quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} F' VM :- rf->porder F O, !,
-  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
-  F' = {{ Build_Formula lp:X' OpLe lp:Y' }}.
-quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} F' VM :- rf->porder F O, !,
-  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
-  F' = {{ Build_Formula lp:X' OpLt lp:Y' }}.
-quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} F' VM :- rf->eq F T, !,
-  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
-  F' = {{ Build_Formula lp:X' OpEq lp:Y' }}.
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote.bop2 i:rf, i:term, o:term, o:term, o:list term.
+quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} OutM Out VM :- rf->porder F O, !,
+  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+  OutM = {{ Internals.Build_MFormula lp:XM' OpLe lp:YM' }},
+  Out = {{ Build_Formula lp:X' OpLe lp:Y' }}.
+quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} OutM Out VM :- rf->porder F O, !,
+  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+  OutM = {{ Internals.Build_MFormula lp:XM' OpLt lp:YM' }},
+  Out = {{ Build_Formula lp:X' OpLt lp:Y' }}.
+quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} OutM Out VM :- rf->eq F T, !,
+  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+  OutM = {{ Internals.Build_MFormula lp:XM' OpEq lp:YM' }},
+  Out = {{ Build_Formula lp:X' OpEq lp:Y' }}.
 
-% [quote.pop2 F In Out VarMap] reifies (in)equalities of type Prop
+% [quote.pop2 F In OutM Out VM] reifies (in)equalities of type Prop
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
+% - [OutM] is a reified expression of type [MFormula]
 % - [Out] is a reified expression of type [Formula Q]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.pop2 i:rf, i:term, o:term, o:list term.
-quote.pop2 F {{ is_true lp:E }} F' VM :- quote.bop2 F E F' VM.
-quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} F' VM :- rf->sort F T, !,
-  quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
-  F' = {{ Build_Formula lp:X' OpEq lp:Y' }}.
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote.pop2 i:rf, i:term, o:term, o:term, o:list term.
+quote.pop2 F {{ is_true lp:E }} OutM Out VM :- quote.bop2 F E OutM Out VM.
+quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} OutM Out VM :- rf->sort F T, !,
+  quote.exprw F X XM' X' VM, !, quote.exprw F Y YM' Y' VM, !,
+  OutM = {{ Internals.Build_MFormula lp:XM' OpEq lp:YM' }},
+  Out = {{ Build_Formula lp:X' OpEq lp:Y' }}.
 
-% [quote.bool F In Out VarMap] reifies boolean formulas
+% [quote.bool F In OutM Out VM] reifies boolean formulas
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [bool],
+% - [OutM] is a reified formula of type [BFormula MFormula Tauto.isBool]
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isBool]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.bool i:rf, i:term, o:term, o:list term.
-quote.bool F {{ lp:F1 ==> lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} VM :- !,
-  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
-quote.bool F {{ lp:F1 && lp:F2 }} {{ AND lp:F1' lp:F2' }} VM :- !,
-  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
-quote.bool F {{ lp:F1 || lp:F2 }} {{ OR lp:F1' lp:F2' }} VM :- !,
-  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
-quote.bool F {{ ~~ lp:F1 }} {{ NOT lp:F1' }} VM :- !, quote.bool F F1 F1' VM.
-quote.bool _ {{ true }} {{ TT Tauto.isBool }} _.
-quote.bool _ {{ false }} {{ FF Tauto.isBool }} _.
-quote.bool F A {{ A Tauto.isBool lp:A' tt }} VM :- quote.bop2 F A A' VM.
-quote.bool _ X {{ X Tauto.isBool lp:X }} _.
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote.bool i:rf, i:term, o:term, o:term, o:list term.
+quote.bool F {{ lp:F1 ==> lp:F2 }} OutM Out VM :- !,
+  quote.bool F F1 OutM1 Out1 VM, !, quote.bool F F2 OutM2 Out2 VM, !,
+  OutM = {{ IMPL lp:OutM1 None lp:OutM2 }},
+  Out = {{ IMPL lp:Out1 None lp:Out2 }}.
+quote.bool F {{ lp:F1 && lp:F2 }} OutM Out VM :- !,
+  quote.bool F F1 OutM1 Out1 VM, !, quote.bool F F2 OutM2 Out2 VM, !,
+  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }}.
+quote.bool F {{ lp:F1 || lp:F2 }} OutM Out VM :- !,
+  quote.bool F F1 OutM1 Out1 VM, !, quote.bool F F2 OutM2 Out2 VM, !,
+  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }}.
+quote.bool F {{ ~~ lp:F1 }} OutM Out VM :- !, quote.bool F F1 OutM1 Out1 VM, !,
+  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}.
+quote.bool _ {{ true }} OutM Out _ :- !,
+  OutM = {{ TT Tauto.isBool }}, Out = {{ TT Tauto.isBool }}.
+quote.bool _ {{ false }} OutM Out _ :- !,
+  OutM = {{ FF Tauto.isBool }}, Out = {{ FF Tauto.isBool }}.
+quote.bool F In OutM Out VM :- quote.bop2 F In OutM' Out' VM,
+  OutM = {{ A Tauto.isBool lp:OutM' tt }},
+  Out = {{ A Tauto.isBool lp:Out' tt }}.
+quote.bool _ In OutM Out _ :-
+  OutM = {{ X Tauto.isBool lp:In }}, Out = {{ X Tauto.isBool lp:In }}.
 
-% [quote.prop F In Out VarMap] reifies formulas of type Prop
+% [quote.prop F In OutM Out VM] reifies formulas of type Prop
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
+% - [OutM] is a reified formula of type [BFormula MFormula Tauto.isProp]
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.prop i:rf, i:term, o:term, o:list term.
-quote.prop F {{ lp:F1 -> lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} VM :- !,
-  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
-quote.prop F {{ iff lp:F1 lp:F2 }} {{ IFF lp:F1' lp:F2' }} VM :- !,
-  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
-quote.prop F {{ lp:F1 /\ lp:F2 }} {{ AND lp:F1' lp:F2' }} VM :- !,
-  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
-quote.prop F {{ lp:F1 \/ lp:F2 }} {{ OR lp:F1' lp:F2' }} VM :- !,
-  quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
-quote.prop F {{ ~ lp:F1 }} {{ NOT lp:F1' }} VM :- !, quote.prop F F1 F1' VM.
-quote.prop _ {{ True }} {{ TT Tauto.isProp }} _.
-quote.prop _ {{ False }} {{ FF Tauto.isProp }} _.
-quote.prop F {{ is_true lp:F1 }} {{ EQ lp:F1' (TT Tauto.isBool) }} VM :- !,
-  quote.bool F F1 F1' VM.
-quote.prop F {{ @eq bool lp:F1 lp:F2 }} {{ EQ lp:F1' lp:F2' }} VM :- !,
-  quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
-quote.prop F A {{ A Tauto.isProp lp:A' tt }} VM :- quote.pop2 F A A' VM.
-quote.prop _ X {{ X Tauto.isProp lp:X }} _.
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote.prop i:rf, i:term, o:term, o:term, o:list term.
+quote.prop F {{ lp:F1 -> lp:F2 }} OutM Out VM :- !,
+  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
+  OutM = {{ IMPL lp:OutM1 None lp:OutM2 }},
+  Out = {{ IMPL lp:Out1 None lp:Out2 }}.
+quote.prop F {{ iff lp:F1 lp:F2 }} OutM Out VM :- !,
+  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
+  OutM = {{ IFF lp:OutM1 lp:OutM2 }}, Out = {{ IFF lp:Out1 lp:Out2 }}.
+quote.prop F {{ lp:F1 /\ lp:F2 }} OutM Out VM :- !,
+  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
+  OutM = {{ AND lp:OutM1 lp:OutM2 }}, Out = {{ AND lp:Out1 lp:Out2 }}.
+quote.prop F {{ lp:F1 \/ lp:F2 }} OutM Out VM :- !,
+  quote.prop F F1 OutM1 Out1 VM, !, quote.prop F F2 OutM2 Out2 VM, !,
+  OutM = {{ OR lp:OutM1 lp:OutM2 }}, Out = {{ OR lp:Out1 lp:Out2 }}.
+quote.prop F {{ ~ lp:F1 }} OutM Out VM :- !, quote.prop F F1 OutM1 Out1 VM, !,
+  OutM = {{ NOT lp:OutM1 }}, Out = {{ NOT lp:Out1 }}.
+quote.prop _ {{ True }} OutM Out _ :- !,
+  OutM = {{ TT Tauto.isProp }}, Out = {{ TT Tauto.isProp }}.
+quote.prop _ {{ False }} OutM Out _ :- !,
+  OutM = {{ FF Tauto.isProp }}, Out = {{ FF Tauto.isProp }}.
+quote.prop F {{ is_true lp:In1 }} OutM Out VM :- !,
+  quote.bool F In1 OutM1 Out1 VM, !,
+  OutM = {{ EQ lp:OutM1 (TT Tauto.isBool) }},
+  Out = {{ EQ lp:Out1 (TT Tauto.isBool) }}.
+quote.prop F {{ @eq bool lp:In1 lp:In2 }} OutM Out VM :- !,
+  quote.bool F In1 OutM1 Out1 VM, !, quote.bool F In2 OutM2 Out2 VM,
+  OutM = {{ EQ lp:OutM1 lp:OutM2 }}, Out = {{ EQ lp:Out1 lp:Out2 }}.
+quote.prop F In OutM Out VM :- quote.pop2 F In OutM' Out' VM,
+  OutM = {{ A Tauto.isProp lp:OutM' tt }},
+  Out = {{ A Tauto.isProp lp:Out' tt }}.
+quote.prop _ In OutM Out _ :-
+  OutM = {{ X Tauto.isProp lp:In }}, Out = {{ X Tauto.isProp lp:In }}.
 
 % [simplify.bool In Out] reduces a boolean formula to [X _]
 % when it doesn't contain any arithmetic part
-% - [In] is a reified formula of type [BFormula (Formula Q) Tauto.isBool],
-% - [Out] is a simplified formula of type [BFormula (Formula Q) Tauto.isBool]
+% - [In] is a reified formula of type [BFormula _ Tauto.isBool],
+% - [Out] is a simplified formula of type [BFormula _ Tauto.isBool]
 pred simplify.bool i:term, o:term.
 simplify.bool {{ IMPL (X _ lp:F1) None (X _ lp:F2) }} F' :-
   F' = {{ X Tauto.isBool (lp:F1 ==> lp:F2) }}.
@@ -265,8 +336,8 @@ simplify.bool X X.
 
 % [simplify.prop In Out] reduces a formula to [X _]
 % when it doesn't contain any arithmetic part
-% - [In] is a reified formula of type [BFormula (Formula Q) Tauto.isProp],
-% - [Out] is a simplified formula of type [BFormula (Formula Q) Tauto.isProp]
+% - [In] is a reified formula of type [BFormula _ Tauto.isProp],
+% - [Out] is a simplified formula of type [BFormula _ Tauto.isProp]
 pred simplify.prop i:term, o:term.
 simplify.prop {{ IMPL (X _ lp:F1) None (X _ lp:F2) }} F' :-
   F' = {{ X Tauto.isProp (lp:F1 -> lp:F2) }}.
@@ -292,35 +363,42 @@ simplify.prop {{ EQ lp:F1 lp:F2 }} {{ EQ lp:F1' lp:F2' }} :-
   simplify.bool F1 F1', simplify.bool F2 F2'.
 simplify.prop X X.
 
-% [quote F In Out VarMap] reifies formulas of type Prop
+% [quote F In Out VM] reifies formulas of type Prop
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
+% - [OutM] is a reified formula of type [BFormula MFormula Tauto.isProp]
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote i:rf, i:term, o:term, o:list term.
-quote F In Out' VM :- quote.prop F In Out VM, simplify.prop Out Out'.
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote i:rf, i:term, o:term, o:term, o:list term.
+quote F In OutM' Out' VM :-
+  quote.prop F In OutM Out VM, simplify.prop OutM OutM', simplify.prop Out Out'.
 
-% [quote.hyps F Hyps Goal ReifiedGoal Out ReifiedOut VarMap] reifies hypotheses
+% [quote.hyps F Hyps Goal ReifiedGoal Out ReifiedOut VM] reifies hypotheses
 % - [F] is a [realDomainType] or [realFieldType] instance,
 % - [Hyps] are hypotheses
 % - [Goal] is the goal, of type [Prop]
+% - [ReifiedGoalM] is the refied goal as a [BFormula MFormula Tauto.isProp]
 % - [ReifiedGoal] is the refied goal as a [BFormula (Formula Q) Tauto.isProp]
 % - [Out] is a chain of implications including [Goal] and hypotheses in [Hyps]
 %   that have some arithmetic content
+% - [ReifiedOutM] is a reified version of [Out]
+%   as a [BFormula MFormula Tauto.isProp]
 % - [ReifiedOut] is a reified version of [Out]
 %   as a [BFormula (Formula Q) Tauto.isProp]
-% - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.hyps i:rf, i:list prop, i:term, i:term, o:term, o:term, o:list term.
-quote.hyps F [decl _ _ H|Ctx] Type TypeF Type'' TypeF'' VM :-
-  quote F H H' VM, not (H' = {{ X _ _ }}), !,
-  quote.hyps F Ctx Type TypeF Type' TypeF' VM,
+% - [VM] is a variable map, that is a list of terms of type [F].
+pred quote.hyps i:rf, i:list prop, i:term, i:term, i:term,
+  o:term, o:term, o:term, o:list term.
+quote.hyps F [decl _ _ H|Ctx] Type TypeFM TypeF Type'' TypeFM'' TypeF'' VM :-
+  quote F H HM' H' VM, not (H' = {{ X _ _ }}), !,
+  quote.hyps F Ctx Type TypeFM TypeF Type' TypeFM' TypeF' VM,
   Type'' = {{ lp:H -> lp:Type' }},
+  TypeFM'' = {{ IMPL lp:HM' None lp:TypeFM' }},
   TypeF'' = {{ IMPL lp:H' None lp:TypeF' }}.
-quote.hyps F [decl _ _ _|Ctx] Type TypeF Type' TypeF' VM :- !,
-  quote.hyps F Ctx Type TypeF Type' TypeF' VM.
-quote.hyps F [def _ _ _ _|Ctx] Type TypeF Type' TypeF' VM :- !,
-  quote.hyps F Ctx Type TypeF Type' TypeF' VM.
-quote.hyps _ [] Type TypeF Type TypeF _.
+quote.hyps F [decl _ _ _|Ctx] Type TypeFM TypeF Type' TypeFM' TypeF' VM :- !,
+  quote.hyps F Ctx Type TypeFM TypeF Type' TypeFM' TypeF' VM.
+quote.hyps F [def _ _ _ _|Ctx] Type TypeFM TypeF Type' TypeFM' TypeF' VM :- !,
+  quote.hyps F Ctx Type TypeFM TypeF Type' TypeFM' TypeF' VM.
+quote.hyps _ [] Type TypeFM TypeF Type TypeFM TypeF _.
 
 % [exfalso_if_not_prop In Out Bool] changes [In] to [False]
 % when [In] is not a [Prop] (and then set [Bool] to [true])
@@ -336,11 +414,12 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 % that are the names of the Ltac1 tactic to call respactively
 % in the [realFieldType] and [realDomainType] case and a third argument [N],
 % passed unchanged as first argument to the previous tactic.
-% The tactics [TacF] or [TacR] will receive five arguments:
+% The tactics [TacF] or [TacR] will receive six arguments:
 % - [N] above
 % - [Efalso] a term of type [bool] indicating if the goal was changed to [False]
 % - [Type''] a term of type [Prop], an implication with the goal
 %   and selected hypotheses
+% - [TypeFM'] the reified [Type''] as a [BFormula MFormula Tauto.isProp]
 % - [TypeF'] the reified [Type''] as a [BFormula (Formula Q) Tauto.isProp]
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
@@ -349,8 +428,12 @@ solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :-
   exfalso_if_not_prop Type Type' Efalso,
   std.rev Ctx Ctx', !,
   rfstr Ctx' Type' F, !,
-  quote F Type' TypeF VM, !,
-  quote.hyps F Ctx' Type' TypeF Type'' TypeF' VM, !,
+  quote F Type' TypeFM TypeF VM, !,
+  quote.hyps F Ctx' Type' TypeFM TypeF Type'' TypeFM' TypeF' VM, !,
+  rf->numDomain F NDF,
+  std.assert-ok!
+    (coq.typecheck TypeFM' {{ BFormula (@Internals.MFormula lp:NDF) isProp }})
+    "The reification produced an ill-typed result, this is a bug.",
   std.assert-ok!
     (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
     "The reification produced an ill-typed result, this is a bug.",
@@ -360,5 +443,6 @@ solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :-
     {{ VarMap.t lp:FS }}
     VM'',
   (if (F = field _) (Tac = TacF) (Tac = TacR)),
-  (coq.ltac.call Tac [N, trm Efalso, trm Type'', trm TypeF', trm VM''] G GL;
+  (coq.ltac.call
+     Tac [N, trm Efalso, trm Type'', trm TypeFM', trm TypeF', trm VM''] G GL;
    coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -90,9 +90,14 @@ fstr.prop {{ @eq bool _ lp:Type }} F :- fstr.bool Type F.
 fstr.prop {{ @eq bool lp:Type _ }} F :- fstr.bool Type F.
 fstr.prop {{ @eq lp:Ty _ _ }} F :- f->sort F Ty.
 
-pred fstr i:term, o:term.
-fstr Type F :- fstr.prop Type F.
-fstr _ _ :- coq.ltac.fail _ "Cannot find a realFieldType".
+pred fstr.hyps i:list prop, o:term.
+fstr.hyps [decl _ _ H|_] F :- fstr.prop H F.
+fstr.hyps [_|Ctx] F :- fstr.hyps Ctx F.
+
+pred fstr i:list prop, i:term, o:term.
+fstr _ Type F :- fstr.prop Type F.
+fstr Ctx _ F :- fstr.hyps Ctx F.
+fstr _ _ _ :- coq.ltac.fail _ "Cannot find a realFieldType".
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Reification procedure
@@ -258,17 +263,43 @@ simplify.prop X X.
 pred quote i:term, i:term, o:term, o:list term.
 quote F In Out' VM :- quote.prop F In Out VM, simplify.prop Out Out'.
 
+% [quote.hyps F Hyps Goal ReifiedGoal Out ReifiedOut VarMap] reifies hypotheses
+% - [F] is a [realFieldType] instance,
+% - [Hyps] are hypotheses
+% - [Goal] is the goal, of type [Prop]
+% - [ReifiedGoal] is the refied goal as a [BFormula (Formula Q) Tauto.isProp]
+% - [Out] is a chain of implications including [Goal] and hypotheses in [Hyps]
+%   that have some arithmetic content
+% - [ReifiedOut] is a reified version of [Out]
+%   as a [BFormula (Formula Q) Tauto.isProp]
+% - [VarMap] is a variable map, that is a list of terms of type [F].
+pred quote.hyps i:term, i:list prop, i:term, i:term, o:term, o:term, o:list term.
+quote.hyps F [decl _ _ H|Ctx] Type TypeF Type'' TypeF'' VM :-
+  quote F H H' VM, not (H' = {{ X _ _ }}), !,
+  quote.hyps F Ctx Type TypeF Type' TypeF' VM,
+  Type'' = {{ lp:H -> lp:Type' }},
+  TypeF'' = {{ IMPL lp:H' None lp:TypeF' }}.
+quote.hyps F [decl _ _ _|Ctx] Type TypeF Type' TypeF' VM :- !,
+  quote.hyps F Ctx Type TypeF Type' TypeF' VM.
+quote.hyps F [def _ _ _ _|Ctx] Type TypeF Type' TypeF' VM :- !,
+  quote.hyps F Ctx Type TypeF Type' TypeF' VM.
+quote.hyps _ [] Type TypeF Type TypeF _.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Main tactic
 
 % This calls the Ltac1 tactic "lraF" with the following arguments:
-% - [TypeF'] the reified goal as a [BFormula (Formula Q) Tauto.isProp]
+% - [Type'] a term of type [Prop], an implication with the goal
+%   and selected hypotheses
+% - [TypeF'] the reified [Type'] as a [BFormula (Formula Q) Tauto.isProp]
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
 %   [realFieldType]
-solve (goal _Ctx _Trigger Type _Proof _Args as G) GL :-
-  fstr Type F, !,
-  quote F Type TypeF' VM, !,
+solve (goal Ctx _Trigger Type _Proof _Args as G) GL :-
+  std.rev Ctx Ctx', !,
+  fstr Ctx' Type F, !,
+  quote F Type TypeF VM, !,
+  quote.hyps F Ctx' Type TypeF Type' TypeF' VM, !,
   std.assert-ok!
     (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
     "The reification produced an ill-typed result, this is a bug.",
@@ -277,5 +308,5 @@ solve (goal _Ctx _Trigger Type _Proof _Args as G) GL :-
     {{ Internals.vm_of_list lp:VM' }}
     {{ VarMap.t lp:FS }}
     VM'',
-  (coq.ltac.call "lraF" [trm TypeF', trm VM''] G GL;
+  (coq.ltac.call "lraF" [trm Type', trm TypeF', trm VM''] G GL;
    coq.ltac.fail 0).

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -41,138 +41,171 @@ nat->Z {{ Init.Nat.of_num_uint lp:X }} XZ :-
 nat->Z {{ lp:X }} XZ :- reduction-Z {{ Z.of_nat lp:X }} XZ.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Casts from realFieldType to various substructures
+% Sum type to contain either realDomainType or realFieldType
+% and casts from both to various substructures
 
-pred f->sort o:term, o:term.
-f->sort F T :- coq.unify-eq {{ Num.RealField.sort lp:F }} T ok.
+% ring or field
+kind rf type.
+type ring term -> rf.
+type field term -> rf.
 
-pred f->eq o:term, o:term.
-f->eq F T :- coq.unify-eq {{ Num.RealField.eqType lp:F }} T ok.
+pred rf->sort o:rf, o:term.
+rf->sort (field F) T :- coq.unify-eq {{ Num.RealField.sort lp:F }} T ok.
+rf->sort (ring R) T :- coq.unify-eq {{ Num.RealDomain.sort lp:R }} T ok.
 
-pred f->porder o:term, o:term.
-f->porder F T :- coq.unify-eq {{ Num.RealField.porderType lp:F }} T ok.
+pred rf->eq o:rf, o:term.
+rf->eq (field F) T :- coq.unify-eq {{ Num.RealField.eqType lp:F }} T ok.
+rf->eq (ring R) T :- coq.unify-eq {{ Num.RealDomain.eqType lp:R }} T ok.
 
-pred f->zmod o:term, o:term.
-f->zmod F T :- coq.unify-eq {{ Num.RealField.zmodType lp:F }} T ok.
+pred rf->porder o:rf, o:term.
+rf->porder (field F) T :- coq.unify-eq {{ Num.RealField.porderType lp:F }} T ok.
+rf->porder (ring R) T :- coq.unify-eq {{ Num.RealDomain.porderType lp:R }} T ok.
 
-pred f->ring o:term, o:term.
-f->ring F T :- coq.unify-eq {{ Num.RealField.ringType lp:F }} T ok.
+pred rf->zmod o:rf, o:term.
+rf->zmod (field F) T :- coq.unify-eq {{ Num.RealField.zmodType lp:F }} T ok.
+rf->zmod (ring R) T :- coq.unify-eq {{ Num.RealDomain.zmodType lp:R }} T ok.
 
-pred f->unitRing o:term, o:term.
-f->unitRing F T :-
+pred rf->ring o:rf, o:term.
+rf->ring (field F) T :- coq.unify-eq {{ Num.RealField.ringType lp:F }} T ok.
+rf->ring (ring R) T :- coq.unify-eq {{ Num.RealDomain.ringType lp:R }} T ok.
+
+pred rf->unitRing o:rf, o:term.
+rf->unitRing (field F) T :-
   coq.unify-eq {{ Num.RealField.unitRingType lp:F }} T ok.
+rf->unitRing (ring R) T :-
+  coq.unify-eq {{ Num.RealDomain.unitRingType lp:R }} T ok.
+
+% [field-mode] is true if we are on a realFieldType,
+% otherwise we are on a realDomainType.
+pred field-mode.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Parse goal (and hypotheses) to extract a realFieldType or realDomainType
 % from (in)equalities it contains
 
-% field structure from a term of type bool
-pred fstr.bool i:term, o:term.
-fstr.bool {{ _ ==> lp:Type }} F :- fstr.bool Type F.
-fstr.bool {{ lp:Type ==> _ }} F :- fstr.bool Type F.
-fstr.bool {{ ~~ lp:Type }} F :- fstr.bool Type F.
-fstr.bool {{ _ && lp:Type }} F :- fstr.bool Type F.
-fstr.bool {{ lp:Type && _ }} F :- fstr.bool Type F.
-fstr.bool {{ _ || lp:Type }} F :- fstr.bool Type F.
-fstr.bool {{ lp:Type || _ }} F :- fstr.bool Type F.
-fstr.bool {{ @Order.le _ lp:Ty _ _ }} F :- f->porder F Ty.
-fstr.bool {{ @Order.lt _ lp:Ty _ _ }} F :- f->porder F Ty.
+% ring or field structure from a term of type bool
+pred rfstr.bool i:term, o:rf.
+rfstr.bool {{ _ ==> lp:Type }} F :- rfstr.bool Type F.
+rfstr.bool {{ lp:Type ==> _ }} F :- rfstr.bool Type F.
+rfstr.bool {{ ~~ lp:Type }} F :- rfstr.bool Type F.
+rfstr.bool {{ _ && lp:Type }} F :- rfstr.bool Type F.
+rfstr.bool {{ lp:Type && _ }} F :- rfstr.bool Type F.
+rfstr.bool {{ _ || lp:Type }} F :- rfstr.bool Type F.
+rfstr.bool {{ lp:Type || _ }} F :- rfstr.bool Type F.
+rfstr.bool {{ @Order.le _ lp:Ty _ _ }} F :- field-mode,
+  rf->porder F Ty, F = field _.
+rfstr.bool {{ @Order.lt _ lp:Ty _ _ }} F :- field-mode,
+  rf->porder F Ty, F = field _.
+rfstr.bool {{ @Order.le _ lp:Ty _ _ }} R :- not field-mode,
+  rf->porder R Ty, R = ring _.
+rfstr.bool {{ @Order.lt _ lp:Ty _ _ }} R :- not field-mode,
+  rf->porder R Ty, R = ring _.
 
-% field structure from a term of type Prop
-pred fstr.prop i:term, o:term.
-fstr.prop {{ _ -> lp:Type }} F :- fstr.prop Type F.
-fstr.prop {{ lp:Type -> _ }} F :- fstr.prop Type F.
-fstr.prop {{ iff _ lp:Type }} F :- fstr.prop Type F.
-fstr.prop {{ iff lp:Type _ }} F :- fstr.prop Type F.
-fstr.prop {{ ~ lp:Type }} F :- fstr.prop Type F.
-fstr.prop {{ _ /\ lp:Type }} F :- fstr.prop Type F.
-fstr.prop {{ lp:Type /\ _ }} F :- fstr.prop Type F.
-fstr.prop {{ _ \/ lp:Type }} F :- fstr.prop Type F.
-fstr.prop {{ lp:Type \/ _ }} F :- fstr.prop Type F.
-fstr.prop {{ is_true lp:Type }} F :- fstr.bool Type F.
-fstr.prop {{ @eq bool _ lp:Type }} F :- fstr.bool Type F.
-fstr.prop {{ @eq bool lp:Type _ }} F :- fstr.bool Type F.
-fstr.prop {{ @eq lp:Ty _ _ }} F :- f->sort F Ty.
+% ring or field structure from a term of type Prop
+pred rfstr.prop i:term, o:rf.
+rfstr.prop {{ _ -> lp:Type }} F :- rfstr.prop Type F.
+rfstr.prop {{ lp:Type -> _ }} F :- rfstr.prop Type F.
+rfstr.prop {{ iff _ lp:Type }} F :- rfstr.prop Type F.
+rfstr.prop {{ iff lp:Type _ }} F :- rfstr.prop Type F.
+rfstr.prop {{ ~ lp:Type }} F :- rfstr.prop Type F.
+rfstr.prop {{ _ /\ lp:Type }} F :- rfstr.prop Type F.
+rfstr.prop {{ lp:Type /\ _ }} F :- rfstr.prop Type F.
+rfstr.prop {{ _ \/ lp:Type }} F :- rfstr.prop Type F.
+rfstr.prop {{ lp:Type \/ _ }} F :- rfstr.prop Type F.
+rfstr.prop {{ is_true lp:Type }} F :- rfstr.bool Type F.
+rfstr.prop {{ @eq bool _ lp:Type }} F :- rfstr.bool Type F.
+rfstr.prop {{ @eq bool lp:Type _ }} F :- rfstr.bool Type F.
+rfstr.prop {{ @eq lp:Ty _ _ }} F :- field-mode, rf->sort F Ty, F = field _.
+rfstr.prop {{ @eq lp:Ty _ _ }} R :- not field-mode, rf->sort R Ty, R = ring _.
 
-pred fstr.hyps i:list prop, o:term.
-fstr.hyps [decl _ _ H|_] F :- fstr.prop H F.
-fstr.hyps [_|Ctx] F :- fstr.hyps Ctx F.
+pred rfstr.hyps i:list prop, o:rf.
+rfstr.hyps [decl _ _ H|_] F :- rfstr.prop H F.
+rfstr.hyps [_|Ctx] F :- rfstr.hyps Ctx F.
 
-pred fstr i:list prop, i:term, o:term.
-fstr _ Type F :- fstr.prop Type F.
-fstr Ctx _ F :- fstr.hyps Ctx F.
-fstr _ _ _ :- coq.ltac.fail _ "Cannot find a realFieldType".
+pred rfstr i:list prop, i:term, o:rf.
+rfstr _ Type F :- field-mode => rfstr.prop Type F.
+rfstr _ Type R :- rfstr.prop Type R.
+rfstr Ctx _ F :- field-mode => rfstr.hyps Ctx F.
+rfstr Ctx _ R :- rfstr.hyps Ctx R.
+rfstr _ _ _ :- coq.ltac.fail _ "Cannot find a realDomainType".
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Reification procedure
 
-% [quote.cst F In Out] reifies rational constants
+% [quote.cstr F In Out] reifies integer constants
+% - [F] is a [realDomainType] or [realFieldType] instance,
+% - [In] is a term of type [F],
+% - [Out] is a reified constant of type [Z]
+pred quote.cstr i:rf, i:term, o:term.
+quote.cstr F {{ GRing.zero lp:Z }} {{ Z0 }} :- rf->zmod F Z.
+quote.cstr F {{ GRing.one lp:R }} {{ (Zpos 1) }} :- rf->ring F R.
+quote.cstr F {{ @GRing.natmul lp:Z (GRing.one lp:R) lp:X }} XZ :-
+  rf->zmod F Z, rf->ring F R, nat->Z X XZ.
+
+% [quote.cstf F In Out] reifies rational constants
 % - [F] is a [realFieldType] instance,
 % - [In] is a term of type [F],
 % - [Out] is a reified constant of type [Q]
-pred quote.cst i:term, i:term, o:term.
-quote.cst F {{ GRing.zero lp:Z }} {{ Qmake 0 1 }} :- f->zmod F Z.
-quote.cst F {{ GRing.one lp:R }} {{ Qmake 1 1 }} :- f->ring F R.
-quote.cst F {{ @GRing.natmul lp:Z (GRing.one lp:R) lp:X }} {{ Qmake lp:XZ 1 }} :-
-  f->zmod F Z, f->ring F R, nat->Z X XZ.
-quote.cst F {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:R) lp:X) }}
-    E' :- f->unitRing F U, f->zmod F Z, f->ring F R,
+pred quote.cstf i:rf, i:term, o:term.
+quote.cstf F {{ @GRing.inv lp:U (@GRing.natmul lp:Z (GRing.one lp:R) lp:X) }}
+    E' :- rf->unitRing F U, rf->zmod F Z, rf->ring F R,
   nat->N X XN, XN = {{ Npos lp:XP }}, !, E' = {{ Qmake 1 lp:XP }}.
 
 % [quote.expr F In Out VarMap] reifies arithmetic expressions
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [F],
 % - [Out] is a reified expression of type [PExpr Q]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.expr i:term, i:term, o:term, o:list term.
-quote.expr F {{ lp:X : _ }} X' VM :- !, quote.expr F X X' VM.
-quote.expr F {{ @GRing.add lp:Z lp:E1 lp:E2 }} E' VM :- f->zmod F Z, !,
+pred quote.expr i:rf, i:term, o:term, o:list term.
+quote.expr F {{ @GRing.add lp:Z lp:E1 lp:E2 }} E' VM :- rf->zmod F Z, !,
   quote.expr F E1 E1' VM, !, quote.expr F E2 E2' VM, !,
   E' = {{ PEadd lp:E1' lp:E2' }}.
-quote.expr F {{ @GRing.opp lp:Z lp:E }} {{ PEopp lp:E' }} VM :- f->zmod F Z, !,
+quote.expr F {{ @GRing.opp lp:Z lp:E }} {{ PEopp lp:E' }} VM :- rf->zmod F Z, !,
   quote.expr F E E' VM.
-quote.expr F {{ @GRing.mul lp:R lp:E1 lp:E2 }} E' VM :- f->ring F R, !,
+quote.expr F {{ @GRing.mul lp:R lp:E1 lp:E2 }} E' VM :- rf->ring F R, !,
   quote.expr F E1 E1' VM, !, quote.expr F E2 E2' VM, !,
   E' = {{ PEmul lp:E1' lp:E2' }}.
 quote.expr F {{ @GRing.exp lp:R lp:E1 lp:X }} E' VM :-
-  f->ring F R, nat->N X XN, !,
+  rf->ring F R, nat->N X XN, !,
   quote.expr F E1 E1' VM, E' = {{ PEpow lp:E1' lp:XN }}.
-quote.expr F E {{ PEc lp:Q }} _ :- quote.cst F E Q.
+quote.expr F E {{ PEc (Qmake lp:Z 1) }} _ :- quote.cstr F E Z.
+quote.expr F E {{ PEc lp:Q }} _ :- F = field _, quote.cstf F E Q.
+quote.expr F {{ lp:X : _ }} X' VM :- !, quote.expr F X X' VM.
 quote.expr _ X Out VarMap :- !, mem VarMap X N, Out = {{ PEX lp:N }}.
 
 % [quote.bop2 F In Out VarMap] reifies boolean (in)equalities
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [bool],
 % - [Out] is a reified expression of type [Formula Q]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.bop2 i:term, i:term, o:term, o:list term.
-quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} F' VM :- f->porder F O, !,
+pred quote.bop2 i:rf, i:term, o:term, o:list term.
+quote.bop2 F {{ @Order.le _ lp:O lp:X lp:Y }} F' VM :- rf->porder F O, !,
   quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
   F' = {{ Build_Formula lp:X' OpLe lp:Y' }}.
-quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} F' VM :- f->porder F O, !,
+quote.bop2 F {{ @Order.lt _ lp:O lp:X lp:Y }} F' VM :- rf->porder F O, !,
   quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
   F' = {{ Build_Formula lp:X' OpLt lp:Y' }}.
-quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} F' VM :- f->eq F T, !,
+quote.bop2 F {{ @eqtype.eq_op lp:T lp:X lp:Y) }} F' VM :- rf->eq F T, !,
   quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
   F' = {{ Build_Formula lp:X' OpEq lp:Y' }}.
 
 % [quote.pop2 F In Out VarMap] reifies (in)equalities of type Prop
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
 % - [Out] is a reified expression of type [Formula Q]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.pop2 i:term, i:term, o:term, o:list term.
+pred quote.pop2 i:rf, i:term, o:term, o:list term.
 quote.pop2 F {{ is_true lp:E }} F' VM :- quote.bop2 F E F' VM.
-quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} F' VM :- f->sort F T, !,
+quote.pop2 F {{ @eq lp:T lp:X lp:Y) }} F' VM :- rf->sort F T, !,
   quote.expr F X X' VM, !, quote.expr F Y Y' VM, !,
   F' = {{ Build_Formula lp:X' OpEq lp:Y' }}.
 
 % [quote.bool F In Out VarMap] reifies boolean formulas
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [bool],
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isBool]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.bool i:term, i:term, o:term, o:list term.
+pred quote.bool i:rf, i:term, o:term, o:list term.
 quote.bool F {{ lp:F1 ==> lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} VM :- !,
   quote.bool F F1 F1' VM, !, quote.bool F F2 F2' VM.
 quote.bool F {{ lp:F1 && lp:F2 }} {{ AND lp:F1' lp:F2' }} VM :- !,
@@ -186,11 +219,11 @@ quote.bool F A {{ A Tauto.isBool lp:A' tt }} VM :- quote.bop2 F A A' VM.
 quote.bool _ X {{ X Tauto.isBool lp:X }} _.
 
 % [quote.prop F In Out VarMap] reifies formulas of type Prop
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.prop i:term, i:term, o:term, o:list term.
+pred quote.prop i:rf, i:term, o:term, o:list term.
 quote.prop F {{ lp:F1 -> lp:F2 }} {{ IMPL lp:F1' None lp:F2' }} VM :- !,
   quote.prop F F1 F1' VM, !, quote.prop F F2 F2' VM.
 quote.prop F {{ iff lp:F1 lp:F2 }} {{ IFF lp:F1' lp:F2' }} VM :- !,
@@ -260,15 +293,15 @@ simplify.prop {{ EQ lp:F1 lp:F2 }} {{ EQ lp:F1' lp:F2' }} :-
 simplify.prop X X.
 
 % [quote F In Out VarMap] reifies formulas of type Prop
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [In] is a term of type [Prop],
 % - [Out] is a reified formula of type [BFormula (Formula Q) Tauto.isProp]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote i:term, i:term, o:term, o:list term.
+pred quote i:rf, i:term, o:term, o:list term.
 quote F In Out' VM :- quote.prop F In Out VM, simplify.prop Out Out'.
 
 % [quote.hyps F Hyps Goal ReifiedGoal Out ReifiedOut VarMap] reifies hypotheses
-% - [F] is a [realFieldType] instance,
+% - [F] is a [realDomainType] or [realFieldType] instance,
 % - [Hyps] are hypotheses
 % - [Goal] is the goal, of type [Prop]
 % - [ReifiedGoal] is the refied goal as a [BFormula (Formula Q) Tauto.isProp]
@@ -277,7 +310,7 @@ quote F In Out' VM :- quote.prop F In Out VM, simplify.prop Out Out'.
 % - [ReifiedOut] is a reified version of [Out]
 %   as a [BFormula (Formula Q) Tauto.isProp]
 % - [VarMap] is a variable map, that is a list of terms of type [F].
-pred quote.hyps i:term, i:list prop, i:term, i:term, o:term, o:term, o:list term.
+pred quote.hyps i:rf, i:list prop, i:term, i:term, o:term, o:term, o:list term.
 quote.hyps F [decl _ _ H|Ctx] Type TypeF Type'' TypeF'' VM :-
   quote F H H' VM, not (H' = {{ X _ _ }}), !,
   quote.hyps F Ctx Type TypeF Type' TypeF' VM,
@@ -299,10 +332,11 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Main tactic
 
-% The tactic takes two arguments, a string [Tac]
-% that is the name of the Ltac1 tactic to call and a second argument [N],
+% The tactic takes three arguments, two strings [TacF] and [TacR]
+% that are the names of the Ltac1 tactic to call respactively
+% in the [realFieldType] and [realDomainType] case and a third argument [N],
 % passed unchanged as first argument to the previous tactic.
-% The tactic [Tac] will receive five arguments:
+% The tactics [TacF] or [TacR] will receive five arguments:
 % - [N] above
 % - [Efalso] a term of type [bool] indicating if the goal was changed to [False]
 % - [Type''] a term of type [Prop], an implication with the goal
@@ -310,20 +344,21 @@ exfalso_if_not_prop _ {{ False }} {{ true }}.
 % - [TypeF'] the reified [Type''] as a [BFormula (Formula Q) Tauto.isProp]
 % - [VM''] a variable map, giving the interpretation to variables in [TypeF']
 %   it is of type [VarMap.t F] where [F] is the carrier for the detected
-%   [realFieldType]
-solve (goal Ctx _Trigger Type _Proof [str Tac, N] as G) GL :-
+%   [realFieldType] or [realDomainType]
+solve (goal Ctx _Trigger Type _Proof [str TacF, str TacR, N] as G) GL :-
   exfalso_if_not_prop Type Type' Efalso,
   std.rev Ctx Ctx', !,
-  fstr Ctx' Type' F, !,
+  rfstr Ctx' Type' F, !,
   quote F Type' TypeF VM, !,
   quote.hyps F Ctx' Type' TypeF Type'' TypeF' VM, !,
   std.assert-ok!
     (coq.typecheck TypeF' {{ BFormula (Formula Q) isProp }})
     "The reification produced an ill-typed result, this is a bug.",
-  f->sort F FS, list-constant FS VM VM',
+  rf->sort F FS, list-constant FS VM VM',
   coq.reduction.vm.norm
     {{ Internals.vm_of_list lp:VM' }}
     {{ VarMap.t lp:FS }}
     VM'',
+  (if (F = field _) (Tac = TacF) (Tac = TacR)),
   (coq.ltac.call Tac [N, trm Efalso, trm Type'', trm TypeF', trm VM''] G GL;
    coq.ltac.fail 0).

--- a/theories/lra.v
+++ b/theories/lra.v
@@ -241,7 +241,8 @@ Definition vm_of_list T (l : list T) : VarMap.t T :=
 End Internals.
 
 (* Main tactic, called from the elpi parser (c.f., lra.elpi) *)
-Ltac lraF ff varmap :=
+Ltac lraF hyps_goal ff varmap :=
+  (suff: hyps_goal by exact);
   let iff := fresh "__ff" in
   let ivarmap := fresh "__varmap" in
   let iwit := fresh "__wit" in
@@ -259,4 +260,4 @@ Elpi Tactic lra.
 Elpi Accumulate File "theories/lra.elpi".
 Elpi Typecheck.
 
-Tactic Notation "lra" := elpi lra.
+Tactic Notation "lra" := elpi lra "lraF".

--- a/theories/lra.v
+++ b/theories/lra.v
@@ -1,0 +1,262 @@
+Require Import DecimalNat DecimalPos List QArith.
+From Coq.micromega Require Import OrderedRing RingMicromega QMicromega EnvRing.
+From Coq.micromega Require Import Refl Tauto Lqa.
+From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint.
+From mathcomp.zify Require Import ssrZ.
+From mathcomp.algebra_tactics Require ring.
+
+Import Order.TTheory GRing.Theory Num.Theory.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Local Open Scope ring_scope.
+
+(* Define [Feval_formula] the semantics of [BFormula (Formula Q) Tauto.isProp]
+   as arithmetic expressions on some [realFieldType].
+   Then prove [FTautoChecker_sound] stating that [QTautoChecker f w = true]
+   implies that the formula [Feval_formula f] holds. *)
+Module Internals.
+
+Section RealDomain.
+
+Variable R : realDomainType.
+
+Lemma Rsor :
+  @SOR R 0 1 +%R *%R (fun x y => x - y) -%R
+       eq (fun x y => x <= y) (fun x y => x < y).
+Proof.
+apply: mk_SOR_theory.
+- exact: RelationClasses.eq_equivalence.
+- by move=> x _ <- y _ <-.
+- by move=> x _ <- y _ <-.
+- by move=> x _ <-.
+- by move=> x _ <- y _ <-.
+- by move=> x _ <- y _ <-.
+- exact: ring.Internals.RR.
+- by [].
+- by move=> x y xley ylex; apply: le_anti; rewrite xley ylex.
+- by move=> x y z; apply: le_trans.
+- move=> x y; rewrite lt_neqAle; split.
+  + by move=> /andP[/eqP yneqx ->]; split.
+  + by move=> [-> /eqP ->].
+- move=> x y; case: (ltgtP x y) => [xlty|yltx|<-].
+  + by left.
+  + by right; right.
+  + by right; left.
+- by move=> x y z; rewrite ler_add2l.
+- exact: mulr_gt0.
+- by apply/eqP; rewrite eq_sym oner_neq0.
+Qed.
+
+Lemma Pos_to_nat_gt0 p : 0 < (Pos.to_nat p)%:R :> R.
+Proof. rewrite ltr0n; exact/ssrnat.ltP/Pos2Nat.is_pos. Qed.
+
+Lemma Pos_to_nat_neq0 p : (Pos.to_nat p)%:R != 0 :> R.
+Proof. by rewrite pnatr_eq0 -lt0n; apply/ssrnat.ltP/Pos2Nat.is_pos. Qed.
+
+Lemma le_int_of_Z x y : Z.le x y -> int_of_Z x <= int_of_Z y.
+Proof.
+case: x y => [|x|x] [|y|y] //.
+- rewrite /Z.le/= Pos.compare_le_iff => xley.
+  by apply/ssrnat.leP; rewrite -Pos2Nat.inj_le.
+- rewrite /Z.le/= -Pos.compare_antisym Pos.compare_le_iff => ylex.
+  by apply/ssrnat.leP/Peano.le_pred; rewrite -Pos2Nat.inj_le.
+Qed.
+
+Lemma Rpower : power_theory 1 *%R eq N.to_nat (@GRing.exp R).
+Proof.
+apply: mkpow_th => x n; case: n => [//|p]; elim: p => [p|p|//] /= IHp.
+- by rewrite Pos2Nat.inj_xI exprS multE mulnC exprM expr2 IHp.
+- by rewrite Pos2Nat.inj_xO multE mulnC exprM expr2 IHp.
+Qed.
+
+Definition Reval_pop2 (o : Op2) : R -> R -> Prop :=
+  match o with
+  | OpEq => eq
+  | OpNEq => fun x y  => ~ x = y
+  | OpLe => fun x y => x <= y
+  | OpGe => fun x y => x >= y
+  | OpLt => fun x y => x < y
+  | OpGt => fun x y => x > y
+  end.
+
+Definition Reval_bop2 (o : Op2) : R -> R -> bool :=
+  match o with
+  | OpEq  => fun x y => x == y
+  | OpNEq => fun x y => x != y
+  | OpLe  => fun x y => x <= y
+  | OpGe  => fun x y => x >= y
+  | OpLt  => fun x y => x < y
+  | OpGt  => fun x y => x > y
+  end.
+
+Definition Reval_op2 (k : Tauto.kind) : Op2 -> R -> R -> Tauto.rtyp k :=
+  match k with isProp => Reval_pop2 | isBool => Reval_bop2 end.
+
+Lemma pop2_bop2 (op : Op2) (q1 q2 : R) :
+  (Reval_bop2 op q1 q2) <-> Reval_pop2 op q1 q2.
+Proof. by case: op => //=; split; move/eqP. Qed.
+
+End RealDomain.
+
+Section RealField.
+
+Variable F : realFieldType.
+
+Definition Q2F (x : Q) : F :=
+  match x with
+  | Qmake n 1 => (int_of_Z n)%:~R
+  | Qmake 1 d => GRing.inv (int_of_Z (Zpos d))%:~R
+  | Qmake n d => (int_of_Z n)%:~R / (nat_of_pos d)%:R
+  end.
+
+Definition Q2F' (x : Q) : F :=
+  (int_of_Z (Qnum x))%:~R / (nat_of_pos (Qden x))%:R.
+
+Lemma Q2F_Q2F' x : Q2F x = Q2F' x.
+Proof.
+rewrite /Q2F/Q2F'.
+by case: x => -[|n|n] [p|p|] //; rewrite ?divr1//;
+  case: n; rewrite // mul1r;
+  rewrite zify_ssreflect.SsreflectZifyInstances.nat_of_posE.
+Qed.
+
+Lemma Q2F0 : Q2F 0 = 0.
+Proof. by rewrite Q2F_Q2F' /Q2F'/= mul0r. Qed.
+
+Lemma Q2F1 : Q2F 1 = 1.
+Proof. by rewrite Q2F_Q2F' /Q2F'/= Pos2Nat.inj_1 divrr// unitr1. Qed.
+
+Lemma Q2F_add x y : Q2F (x + y) = Q2F x + Q2F y.
+Proof.
+rewrite !Q2F_Q2F' /Q2F'/= rmorphD/= !rmorphM/= nat_of_mul_pos intrD.
+rewrite !intrM natrM mulrDl [(int_of_Z (Qnum y))%:~R * _]mulrC -!mulf_div.
+rewrite !zify_ssreflect.SsreflectZifyInstances.nat_of_posE -!pmulrn.
+by rewrite !divff ?Pos_to_nat_neq0// mulr1 mul1r.
+Qed.
+
+Lemma Q2F_opp x : Q2F (- x) = - Q2F x.
+Proof. by rewrite !Q2F_Q2F' /Q2F'/= rmorphN/= mulrNz mulNr. Qed.
+
+Lemma Q2F_sub x y : Q2F (x - y) = Q2F x - Q2F y.
+Proof. by rewrite Q2F_add Q2F_opp. Qed.
+
+Lemma Q2F_mul x y : Q2F (x * y) = Q2F x * Q2F y.
+Proof.
+by rewrite !Q2F_Q2F' /Q2F'/= rmorphM/= nat_of_mul_pos intrM natrM mulf_div.
+Qed.
+
+Lemma Q2F_eq x y : Qeq_bool x y = (Q2F x == Q2F y).
+Proof.
+rewrite !Q2F_Q2F' /Q2F'.
+rewrite !zify_ssreflect.SsreflectZifyInstances.nat_of_posE.
+rewrite GRing.eqr_div ?Pos_to_nat_neq0// !pmulrn -!intrM eqr_int.
+apply/idP/idP.
+- by move=> /Qeq_bool_eq/(f_equal int_of_Z); rewrite 2!rmorphM => ->.
+- move=> /eqP eq; apply: Qeq_eq_bool.
+  by rewrite /Qeq -[LHS]int_of_ZK -[RHS]int_of_ZK rmorphM/= eq !rmorphM.
+Qed.
+
+Lemma Q2F_le x y : Qle_bool x y = true -> Q2F x <= Q2F y.
+Proof.
+rewrite !Q2F_Q2F' /Q2F' Qle_bool_iff => /le_int_of_Z; rewrite !rmorphM/= => le.
+rewrite !zify_ssreflect.SsreflectZifyInstances.nat_of_posE.
+rewrite ler_pdivr_mulr ?Pos_to_nat_gt0// mulrAC.
+by rewrite ler_pdivl_mulr ?Pos_to_nat_gt0// !pmulrn -!intrM ler_int.
+Qed.
+
+Lemma FQ : ring_morph 0 1 +%R *%R (fun x y : F => x - y) -%R eq
+                      0%Q 1%Q Qplus Qmult Qminus Qopp Qeq_bool Q2F.
+Proof.
+apply: mkmorph.
+- exact: Q2F0.
+- exact: Q2F1.
+- exact: Q2F_add.
+- exact: Q2F_sub.
+- exact: Q2F_mul.
+- exact: Q2F_opp.
+- by move=> x y; rewrite Q2F_eq => /eqP.
+Qed.
+
+Lemma FSORaddon :
+  @SORaddon F 0 1 +%R *%R (fun x y => x - y) -%R eq (fun x y => x <= y) (* ring elements *)
+  Q 0%Q 1%Q Qplus Qmult Qminus Qopp Qeq_bool Qle_bool (* coefficients *)
+  Q2F nat N.to_nat (@GRing.exp F).
+Proof.
+apply: mk_SOR_addon.
+- exact: FQ.
+- exact: Rpower.
+- by move=> x y; rewrite Q2F_eq => /negbT/eqP.
+- exact: Q2F_le.
+Qed.
+
+Definition Feval_expr :=
+  eval_pexpr +%R *%R (fun x y => x - y) -%R Q2F N.to_nat (@GRing.exp F).
+
+Definition Feval_formula (e : PolEnv F) (k : Tauto.kind) (ff : Formula Q) :=
+  let (lhs,o,rhs) := ff in Reval_op2 k o (Feval_expr e lhs) (Feval_expr e rhs).
+
+Definition Feval_formula' :=
+  eval_formula
+    +%R *%R (fun x y => x - y) -%R
+    eq (fun x y => x <= y) (fun x y => x < y) Q2F N.to_nat (@GRing.exp F).
+
+Lemma Feval_formula_compat env b f :
+  Tauto.hold b (Feval_formula env b f) <-> Feval_formula' env f.
+Proof. by case: f => lhs op rhs; case: b => //=; rewrite pop2_bop2. Qed.
+
+Definition Feval_nformula :=
+  eval_nformula 0 +%R *%R eq (fun x y => x <= y) (fun x y => x < y) Q2F.
+
+Lemma FTautoChecker_sound f w : QTautoChecker f w = true ->
+  forall env, eval_bf (Feval_formula env) f.
+Proof.
+apply: (tauto_checker_sound _ _ _ _ Feval_nformula).
+- exact: (eval_nformula_dec (Rsor F)).
+- by move=> [? ?] ? ?; apply: (check_inconsistent_sound (Rsor F) FSORaddon).
+- move=> t t' u deducett'u env evalt evalt'.
+  exact: (nformula_plus_nformula_correct (Rsor F) FSORaddon env t t').
+- move=> env k ff tg cnfff; rewrite Feval_formula_compat.
+  exact: (cnf_normalise_correct (Rsor F) FSORaddon env ff tg).1.
+- move=> env k ff tg cnfff; rewrite Tauto.hold_eNOT Feval_formula_compat.
+  exact: (cnf_negate_correct (Rsor F) FSORaddon env ff tg).1.
+- move=> t w0 checkw0 env.
+  rewrite (make_impl_map (Feval_nformula env))//.
+  exact: (checker_nf_sound (Rsor F) FSORaddon) checkw0 env.
+Qed.
+
+End RealField.
+
+(* Auxiliary function called from lra.elpi *)
+Definition vm_of_list T (l : list T) : VarMap.t T :=
+  let fix aux acc p l :=
+    match l with
+    | [::] => acc
+    | x :: l => aux (VarMap.vm_add x p x acc) (Pos.succ p) l
+    end in
+  aux VarMap.Empty 1%positive l.
+
+End Internals.
+
+(* Main tactic, called from the elpi parser (c.f., lra.elpi) *)
+Ltac lraF ff varmap :=
+  let iff := fresh "__ff" in
+  let ivarmap := fresh "__varmap" in
+  let iwit := fresh "__wit" in
+  let iprf := fresh "__prf" in
+  pose (iff := ff);
+  pose (ivarmap := varmap);
+  wlra_Q iwit ff;
+  pose (iprf := erefl true <: QTautoChecker iff iwit = true);
+  change (eval_bf (Internals.Feval_formula (VarMap.find 0 ivarmap)) iff);
+  exact (Internals.FTautoChecker_sound iprf (VarMap.find 0 ivarmap)).
+
+From elpi Require Import elpi.
+
+Elpi Tactic lra.
+Elpi Accumulate File "theories/lra.elpi".
+Elpi Typecheck.
+
+Tactic Notation "lra" := elpi lra.

--- a/theories/lra.v
+++ b/theories/lra.v
@@ -363,11 +363,19 @@ Proof.
 by rewrite !Q2F_Q2F' /Q2F'/= rmorphM/= nat_of_mul_pos intrM natrM mulf_div.
 Qed.
 
+(* TODO: remove once we require MathComp >= 1.13 *)
+Lemma eqr_div (U : fieldType) (x y z t : U) :
+  y != 0 -> t != 0 -> (x / y == z / t) = (x * t == z * y).
+Proof.
+move=> yD0 tD0; rewrite -[x in RHS](divfK yD0) -[z in RHS](divfK tD0) mulrAC.
+by apply/eqP/eqP => [->|/(mulIf yD0)/(mulIf tD0)].
+Qed.
+
 Lemma Q2F_eq x y : Qeq_bool x y = (Q2F x == Q2F y :> F).
 Proof.
 rewrite !Q2F_Q2F' /Q2F'.
 rewrite !zify_ssreflect.SsreflectZifyInstances.nat_of_posE.
-rewrite GRing.eqr_div ?Pos_to_nat_neq0// !pmulrn -!intrM eqr_int.
+rewrite eqr_div ?Pos_to_nat_neq0// !pmulrn -!intrM eqr_int.
 apply/idP/idP.
 - by move=> /Qeq_bool_eq/(f_equal int_of_Z); rewrite 2!rmorphM => ->.
 - move=> /eqP eq; apply: Qeq_eq_bool.

--- a/theories/lra.v
+++ b/theories/lra.v
@@ -241,7 +241,8 @@ Definition vm_of_list T (l : list T) : VarMap.t T :=
 End Internals.
 
 (* Main tactic, called from the elpi parser (c.f., lra.elpi) *)
-Ltac lraF hyps_goal ff varmap :=
+Ltac lraF efalso hyps_goal ff varmap :=
+  match efalso with true => exfalso | _ => idtac end;
   (suff: hyps_goal by exact);
   let iff := fresh "__ff" in
   let ivarmap := fresh "__varmap" in

--- a/theories/lra.v
+++ b/theories/lra.v
@@ -13,12 +13,12 @@ Unset Printing Implicit Defensive.
 
 Local Open Scope ring_scope.
 
-(* Define [Feval_formula] the semantics of [BFormula (Formula Q) Tauto.isProp]
-   as arithmetic expressions on some [realFieldType].
-   Then prove [FTautoChecker_sound] stating that [QTautoChecker f w = true]
-   implies that the formula [Feval_formula f] holds. *)
 Module Internals.
 
+(* Define [Reval_formula] the semantics of [BFormula (Formula Z) Tauto.isProp]
+   as arithmetic expressions on some [realDomainType].
+   Then prove [RTautoChecker_sound] stating that [ZTautoChecker f w = true]
+   implies that the formula [Reval_formula f] holds. *)
 Section RealDomain.
 
 Variable R : realDomainType.
@@ -74,11 +74,32 @@ Definition int_of_Z' (z : Z) : int :=
 Lemma int_of_Z_int_of_Z' n : int_of_Z n = int_of_Z' n.
 Proof. by case: n => //= p; rewrite pos_to_nat_pos_to_nat'. Qed.
 
+Definition Z2R (x : Z) : R := (int_of_Z' x)%:~R.
+
 Lemma Pos_to_nat_gt0 p : 0 < (Pos.to_nat p)%:R :> R.
 Proof. rewrite ltr0n; exact/ssrnat.ltP/Pos2Nat.is_pos. Qed.
 
 Lemma Pos_to_nat_neq0 p : (Pos.to_nat p)%:R != 0 :> R.
 Proof. by rewrite pnatr_eq0 -lt0n; apply/ssrnat.ltP/Pos2Nat.is_pos. Qed.
+
+Lemma Z2R_add x y : Z2R (x + y) = Z2R x + Z2R y.
+Proof. by rewrite /Z2R -!int_of_Z_int_of_Z' !rmorphD/=. Qed.
+
+Lemma Z2R_opp x : Z2R (- x) = - Z2R x.
+Proof. by rewrite /Z2R -!int_of_Z_int_of_Z' !rmorphN. Qed.
+
+Lemma Z2R_sub x y : Z2R (x - y) = Z2R x - Z2R y.
+Proof. by rewrite Z2R_add Z2R_opp. Qed.
+
+Lemma Z2R_mul x y : Z2R (x * y) = Z2R x * Z2R y.
+Proof. by rewrite /Z2R -!int_of_Z_int_of_Z' !rmorphM. Qed.
+
+Lemma Z2R_eq x y : Z.eqb x y = (Z2R x == Z2R y).
+Proof.
+rewrite /Z2R -!int_of_Z_int_of_Z' eqr_int.
+apply/idP/idP; first by move=> /Z.eqb_spec ->.
+by move=> /eqP/(f_equal Z_of_int); rewrite !int_of_ZK => ->; apply/Z.eqb_spec.
+Qed.
 
 Lemma le_int_of_Z x y : Z.le x y -> int_of_Z x <= int_of_Z y.
 Proof.
@@ -89,12 +110,43 @@ case: x y => [|x|x] [|y|y] //.
   by apply/ssrnat.leP/Peano.le_pred; rewrite -Pos2Nat.inj_le.
 Qed.
 
+Lemma Z2R_le x y : Z.leb x y = true -> Z2R x <= Z2R y.
+Proof.
+rewrite /Z2R -!int_of_Z_int_of_Z' ler_int => /Z.leb_le; exact: le_int_of_Z.
+Qed.
+
+Lemma RZ : ring_morph 0 1 +%R  *%R (fun x y : R => x - y) -%R eq
+                      Z0 (Zpos 1) Z.add Z.mul Z.sub Z.opp Z.eqb Z2R.
+Proof.
+apply: mkmorph => //.
+- exact: Z2R_add.
+- exact: Z2R_sub.
+- exact: Z2R_mul.
+- exact: Z2R_opp.
+- by move=> x y; rewrite Z2R_eq => /eqP.
+Qed.
+
 Lemma Rpower : power_theory 1 *%R eq N.to_nat (@GRing.exp R).
 Proof.
 apply: mkpow_th => x n; case: n => [//|p]; elim: p => [p|p|//] /= IHp.
 - by rewrite Pos2Nat.inj_xI exprS multE mulnC exprM expr2 IHp.
 - by rewrite Pos2Nat.inj_xO multE mulnC exprM expr2 IHp.
 Qed.
+
+Lemma RSORaddon :
+  @SORaddon R 0 1 +%R *%R (fun x y => x - y) -%R eq (fun x y => x <= y) (* ring elements *)
+  Z Z0 (Zpos 1) Z.add Z.mul Z.sub Z.opp Z.eqb Z.leb (* coefficients *)
+  Z2R nat N.to_nat (@GRing.exp R).
+Proof.
+apply: mk_SOR_addon.
+- exact: RZ.
+- exact: Rpower.
+- by move=> x y; rewrite Z2R_eq => /negbT/eqP.
+- exact: Z2R_le.
+Qed.
+
+Definition Reval_expr :=
+  eval_pexpr +%R *%R (fun x y => x - y) -%R Z2R N.to_nat (@GRing.exp R).
 
 Definition Reval_pop2 (o : Op2) : R -> R -> Prop :=
   match o with
@@ -119,12 +171,60 @@ Definition Reval_bop2 (o : Op2) : R -> R -> bool :=
 Definition Reval_op2 (k : Tauto.kind) : Op2 -> R -> R -> Tauto.rtyp k :=
   match k with isProp => Reval_pop2 | isBool => Reval_bop2 end.
 
+Definition Reval_formula (e : PolEnv R) (k : Tauto.kind) (ff : Formula Z) :=
+  let (lhs,o,rhs) := ff in Reval_op2 k o (Reval_expr e lhs) (Reval_expr e rhs).
+
+Definition Reval_formula' :=
+  eval_formula
+    +%R *%R (fun x y => x - y) -%R
+    eq (fun x y => x <= y) (fun x y => x < y) Z2R N.to_nat (@GRing.exp R).
+
 Lemma pop2_bop2 (op : Op2) (q1 q2 : R) :
   (Reval_bop2 op q1 q2) <-> Reval_pop2 op q1 q2.
 Proof. by case: op => //=; split; move/eqP. Qed.
 
+Lemma Reval_formula_compat env b f :
+  Tauto.hold b (Reval_formula env b f) <-> Reval_formula' env f.
+Proof. by case: f => lhs op rhs; case: b => //=; rewrite pop2_bop2. Qed.
+
+Definition Reval_nformula :=
+  eval_nformula 0 +%R *%R eq (fun x y => x <= y) (fun x y => x < y) Z2R.
+
+Definition ZTautoChecker (f : BFormula (Formula Z) Tauto.isProp)
+    (w: list (Psatz Z)) : bool :=
+  @tauto_checker
+    (Formula Z) (NFormula Z) unit
+    (check_inconsistent Z0 Z.eqb Z.leb)
+    (nformula_plus_nformula Z0 Z.add Z.eqb)
+    (@cnf_normalise Z Z0 (Zpos 1) Z.add Z.mul Z.sub Z.opp Z.eqb Z.leb unit)
+    (@cnf_negate Z Z0 (Zpos 1) Z.add Z.mul Z.sub Z.opp Z.eqb Z.leb unit)
+    (Psatz Z)
+    (fun cl => check_normalised_formulas
+                 Z0 (Zpos 1) Z.add Z.mul Z.eqb Z.leb (List.map fst cl)) f w.
+
+Lemma RTautoChecker_sound f w : ZTautoChecker f w = true ->
+  forall env, eval_bf (Reval_formula env) f.
+Proof.
+apply: (tauto_checker_sound _ _ _ _ Reval_nformula).
+- exact: (eval_nformula_dec Rsor).
+- by move=> [? ?] ? ?; apply: (check_inconsistent_sound Rsor RSORaddon).
+- move=> t t' u deducett'u env evalt evalt'.
+  exact: (nformula_plus_nformula_correct Rsor RSORaddon env t t').
+- move=> env k ff tg cnfff; rewrite Reval_formula_compat.
+  exact: (cnf_normalise_correct Rsor RSORaddon env ff tg).1.
+- move=> env k ff tg cnfff; rewrite Tauto.hold_eNOT Reval_formula_compat.
+  exact: (cnf_negate_correct Rsor RSORaddon env ff tg).1.
+- move=> t w0 checkw0 env.
+  rewrite (make_impl_map (Reval_nformula env))//.
+  exact: (checker_nf_sound Rsor RSORaddon) checkw0 env.
+Qed.
+
 End RealDomain.
 
+(* Define [Feval_formula] the semantics of [BFormula (Formula Q) Tauto.isProp]
+   as arithmetic expressions on some [realFieldType].
+   Then prove [FTautoChecker_sound] stating that [QTautoChecker f w = true]
+   implies that the formula [Feval_formula f] holds. *)
 Section RealField.
 
 Variable F : realFieldType.
@@ -262,9 +362,81 @@ Definition vm_of_list T (l : list T) : VarMap.t T :=
     end in
   aux VarMap.Empty 1%positive l.
 
+(* Translating formulas and witnesses from Q to Z for the realDomainType case *)
+
+Definition omap2 {aT1 aT2 rT} (f : aT1 -> aT2 -> rT) o1 o2 :=
+  obind (fun a1 => omap (f a1) o2) o1.
+
+Fixpoint PExpr_Q2Z (e : PExpr Q) : option (PExpr Z) := match e with
+  | PEc (Qmake z 1) => Some (PEc z) | PEc _ => None
+  | PEX n => Some (PEX n)
+  | PEadd e1 e2 => omap2 PEadd (PExpr_Q2Z e1) (PExpr_Q2Z e2)
+  | PEsub e1 e2 => omap2 PEsub (PExpr_Q2Z e1) (PExpr_Q2Z e2)
+  | PEmul e1 e2 => omap2 PEmul (PExpr_Q2Z e1) (PExpr_Q2Z e2)
+  | PEopp e1 => omap PEopp (PExpr_Q2Z e1)
+  | PEpow e1 n => omap (PEpow ^~ n) (PExpr_Q2Z e1) end.
+
+Definition Formula_Q2Z (ff : Formula Q) : option (Formula Z) :=
+  omap2
+    (fun l r => Build_Formula l (Fop ff) r)
+    (PExpr_Q2Z (Flhs ff)) (PExpr_Q2Z (Frhs ff)).
+
+Fixpoint BFormula_Q2Z [k] (ff : BFormula (Formula Q) k) :
+    option (BFormula (Formula Z) k) := match ff with
+  | TT k => Some (TT k)
+  | FF k => Some (FF k)
+  | X k P => Some (X k P)
+  | A k a aa => omap (A k ^~ aa) (Formula_Q2Z a)
+  | AND _ f1 f2 => omap2 (fun f => AND f) (BFormula_Q2Z f1) (BFormula_Q2Z f2)
+  | OR _ f1 f2 => omap2 (fun f => OR f) (BFormula_Q2Z f1) (BFormula_Q2Z f2)
+  | NOT _ f1 => omap (fun f => NOT f) (BFormula_Q2Z f1)
+  | IMPL _ f1 o f2 =>
+      omap2 (fun f => IMPL f o) (BFormula_Q2Z f1) (BFormula_Q2Z f2)
+  | IFF _ f1 f2 => omap2 (fun f => IFF f) (BFormula_Q2Z f1) (BFormula_Q2Z f2)
+  | EQ f1 f2 => omap2 EQ (BFormula_Q2Z f1) (BFormula_Q2Z f2) end.
+
+Fixpoint Pol_Q2Z (p : Pol Q) : Pol Z * positive := match p with
+  | Pc (Qmake n d) => (Pc n, d)
+  | Pinj j p => let (p, n) := Pol_Q2Z p in (Pinj j p, n)
+  | PX p1 i p2 =>
+      let (p1, n1) := Pol_Q2Z p1 in
+      let (p2, n2) := Pol_Q2Z p2 in
+      let mulc c p := PmulC Z0 (Zpos 1) Z.mul Z.eqb p (Zpos c) in
+      (PX (mulc n2 p1) i (mulc n1 p2), Pos.mul n1 n2)
+  end.
+
+Fixpoint Psatz_Q2Z (l : seq positive) (p : Psatz Q) : Psatz Z * positive :=
+  match p with
+  | PsatzC (Qmake n d) => (PsatzC n, d)
+  | PsatzLet p1 p2 =>
+      let (p1, n1) := Psatz_Q2Z l p1 in
+      let (p2, n2) := Psatz_Q2Z (n1 :: l) p2 in
+      (PsatzLet p1 p2, n2)
+  | PsatzIn n => (PsatzIn _ n, nth 1%positive l n)
+  | PsatzSquare p => let (p, n) := Pol_Q2Z p in (PsatzSquare p, Pos.mul n n)
+  | PsatzMulC p1 p2 =>
+      let (p1, n1) := Pol_Q2Z p1 in
+      let (p2, n2) := Psatz_Q2Z l p2 in
+      (PsatzMulC p1 p2, Pos.mul n1 n2)
+  | PsatzMulE p1 p2 =>
+      let (p1, n1) := Psatz_Q2Z l p1 in
+      let (p2, n2) := Psatz_Q2Z l p2 in
+      (PsatzMulE p1 p2, Pos.mul n1 n2)
+  | PsatzAdd p1 p2 =>
+      let (p1, n1) := Psatz_Q2Z l p1 in
+      let (p2, n2) := Psatz_Q2Z l p2 in
+      let mulc c p := PsatzMulE (PsatzC (Zpos c)) p in
+      (PsatzAdd (mulc n2 p1) (mulc n1 p2), Pos.mul n1 n2)
+  | PsatzZ => (PsatzZ _, 1%positive)
+  end.
+
+Definition seq_Psatz_Q2Z : seq (Psatz Q) -> seq (Psatz Z) :=
+  map (fun p => fst (Psatz_Q2Z [::] p)).
+
 End Internals.
 
 (* Main tactics, called from the elpi parser (c.f., lra.elpi) *)
+
 Ltac tacF tac efalso hyps_goal ff varmap :=
   match efalso with true => exfalso | _ => idtac end;
   (suff: hyps_goal by exact);
@@ -284,16 +456,40 @@ Ltac psatzF n :=
   let sos_or_psatzn w f := wsos_Q w f || wpsatz_Q n w f in
   tacF sos_or_psatzn.
 
+Ltac tacR tac efalso hyps_goal ff varmap :=
+  match efalso with true => exfalso | _ => idtac end;
+  (suff: hyps_goal by exact);
+  let iff := fresh "__ff" in
+  let ivarmap := fresh "__varmap" in
+  let iwit := fresh "__wit" in
+  let iprf := fresh "__prf" in
+  match eval vm_compute in (Internals.BFormula_Q2Z ff) with
+  | Some ?f =>
+      pose (iff := f);
+      pose (ivarmap := varmap);
+      tac iwit ff;
+      let tr := Internals.seq_Psatz_Q2Z in
+      pose (iprf := erefl true <: Internals.ZTautoChecker iff (tr iwit) = true);
+      change (eval_bf (Internals.Reval_formula (VarMap.find 0 ivarmap)) iff);
+      exact (Internals.RTautoChecker_sound iprf (VarMap.find 0 ivarmap))
+  | _ => fail  (* should never happen, the parser only parses int constants *)
+  end.
+Ltac lraR n := let wlra_Q w f := wlra_Q w f in tacR wlra_Q.
+Ltac nraR n := let wnra_Q w f := wnra_Q w f in tacR wnra_Q.
+Ltac psatzR n :=
+  let sos_or_psatzn w f := wsos_Q w f || wpsatz_Q n w f in
+  tacF sos_or_psatzn.
+
 From elpi Require Import elpi.
 
 Elpi Tactic lra.
 Elpi Accumulate File "theories/lra.elpi".
 Elpi Typecheck.
 
-Tactic Notation "lra" := elpi lra "lraF" 0.
-Tactic Notation "nra" := elpi lra "nraF" 0.
-Tactic Notation "psatz" integer(n) := elpi lra "psatzF" ltac_int:(n).
-Tactic Notation "psatz" := elpi lra "psatzF" (-1).
+Tactic Notation "lra" := elpi lra "lraF" "lraR" 0.
+Tactic Notation "nra" := elpi lra "nraF" "nraR" 0.
+Tactic Notation "psatz" integer(n) := elpi lra "psatzF" "psatzR" ltac_int:(n).
+Tactic Notation "psatz" := elpi lra "psatzF" "psatzR" (-1).
 
 (* Avoid some stack overflows with large constants *)
 #[global] Opaque Init.Nat.of_num_uint.


### PR DESCRIPTION
This is a Work In Progress to get lra (Linear Real Arithmetic) with MathComp. The parser needs to be completed but it already handles the following examples:
```Coq
From mathcomp Require Import all_ssreflect ssralg ssrnum rat.
From mathcomp Require Import lra.

Local Open Scope ring_scope.

Lemma test (F : realDomainType) (x y : F) :
  x + 2%:R * y ≤ 3%:R → 2%:R * x + y ≤ 3%:R → x + y ≤ 2%:R.
Proof.
lra.
Qed.

(* Print test. *)
(* Print Assumptions test.  (* Closed under the global context *) *)

Lemma test_rat (x y : rat) :
  x + 2%:R * y ≤ 3%:R → 2%:R * x + y ≤ 3%:R → x + y ≤ 2%:R.
Proof.
lra.
Qed.

Lemma test_rat_constant (F : realFieldType) (x : F) :
  0 ≤ x → 1 / 3 * x ≤ 2^-1 * x.
Proof.
lra.
Qed.
```

We also have `nra` and `psatz`.

The minimal assumption is a `realDomainType` because we need both a total order and a ring structure. This enables integer constants. In presence of a `realFieldType`, rational constants are understood.

This requires https://github.com/coq/coq/pull/15921 to export micromega witness generation as Ltac1 tactics and use an elpi parser.