### PR TITLE
Simplify the normalization functions for preprocessing

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,5 +1,5 @@
 # This file was generated from `meta.yml` using the coq-community templates and
-# then patched to support the test-suite. Be careful when regenerate it.
+# then patched to support the test-suite. Be careful when regenerating it.
 name: Docker CI
 
 on:
@@ -24,7 +24,7 @@ jobs:
           - 'mathcomp/mathcomp:1.17.0-coq-8.17'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-mathcomp-algebra-tactics.opam'

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -20,8 +20,8 @@ jobs:
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
           - 'mathcomp/mathcomp:1.16.0-coq-8.16'
           - 'mathcomp/mathcomp:1.16.0-coq-8.17'
-          - 'mathcomp/mathcomp-dev:coq-8.16'
-          - 'mathcomp/mathcomp-dev:coq-8.17'
+          - 'mathcomp/mathcomp:1.17.0-coq-8.16'
+          - 'mathcomp/mathcomp:1.17.0-coq-8.17'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/meta.yml
+++ b/meta.yml
@@ -50,10 +50,10 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.16.0-coq-8.17'
   repo: 'mathcomp/mathcomp'
-- version: 'coq-8.16'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.17'
-  repo: 'mathcomp/mathcomp-dev'
+- version: '1.17.0-coq-8.16'
+  repo: 'mathcomp/mathcomp'
+- version: '1.17.0-coq-8.17'
+  repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:

--- a/theories/lra.elpi
+++ b/theories/lra.elpi
@@ -170,7 +170,7 @@ quote.int {{ Negz lp:N }} {{ large_int_Z (Zneg lp:P) }} (coqZneg P) :-
 % - [F] is optionally a [fieldType] instance such that
 %   [GRing.Field.ringType F = R],
 % - [TR] is a [ringType] instance,
-% - [TUR] is optionally an [unitRingType] instance such that
+% - [TUR] is optionally a [unitRingType] instance such that
 %   [GRing.UnitRing.ringType TUR = TR],
 % - [Morph] is a function from [R] to [TR],
 % - [In] is a term of type [R],


### PR DESCRIPTION
They do not have to take a homomorphism, but a function.

I wished to have a slight performance improvement with this change, but it is not really noticible in `from_sander.v`.