### PR TITLE
Lookup abstracted terms using unification

### DIFF
--- a/theories/common.elpi
+++ b/theories/common.elpi
@@ -7,6 +7,7 @@ list-constant T [X|XS] {{ @cons lp:T lp:X lp:XS' }} :- list-constant T XS XS'.
 
 pred mem o:list term, o:term, o:int.
 mem [X|_] X 0 :- !.
+mem [Y|_] X 0 :- coq.unify-eq X Y ok, !.
 mem [_|XS] X M :- !, mem XS X N, M is N + 1.
 
 % [eucldiv N D M R] N = D * M + R


### PR DESCRIPTION
When `quote.ring` finds a term that it can not translate, it looks it up in a list of terms it has already abstracted and if it does not find it adds it to the list. This is not robust to composition of coercions however, since it uses equality of terms instead of unification.