### PR TITLE
Fix #110 (stabilize field tactic)

### DIFF
--- a/examples/field_examples.v
+++ b/examples/field_examples.v
@@ -49,3 +49,8 @@ Proof. by move=> F n n_neq0; field; rewrite subr_eq0 pnatr_eq1. Qed.
 Goal forall (F : numFieldType) (n : nat),
   n != 1%N -> (2%:R - (2 * n)%:R) / (1 - n%:R) = 2%:R :> F.
 Proof. by move=> F n n_neq0; field; rewrite subr_eq0 eq_sym pnatr_eq1. Qed.
+
+(* https://github.com/math-comp/algebra-tactics/issues/110 *)
+Goal forall (F : fieldType) (x y : F), x != 0 -> y != 0 ->
+  1 / (x * y) = 1 / x * 1 / y.
+Proof. by move=> F x y xNZ yNZ; field. Qed.

--- a/theories/ring.v
+++ b/theories/ring.v
@@ -400,6 +400,9 @@ Ltac field_normalization :=
   rewrite ?{zero}zeroE ?{one}oneE ?{add}addE ?{mul}mulE ?{sub}subE ?{opp}oppE;
   rewrite ?{Feqb}FeqbE ?{F_of_nat}F_of_natE ?{exp}expE ?{l}lE.
 
+Ltac field_postprocessing :=
+  do ?[apply/andP; split].
+
 End Internals.
 
 (* Auxiliary Ltac code which will be invoked from Elpi *)
@@ -417,7 +420,7 @@ Ltac ring_reflection := ring_reflection_check.
 
 Ltac field_reflection_check Lem F VarMap Lpe RE1 RE2 PE1 PE2 LpeProofs :=
   refine (Lem F 100%N VarMap Lpe RE1 RE2 PE1 PE2 LpeProofs
-              ltac:(reflexivity) ltac:(field_normalization)).
+          ltac:(reflexivity) ltac:(field_normalization; field_postprocessing)).
 
 Ltac field_reflection_no_check Lem F VarMap Lpe RE1 RE2 PE1 PE2 LpeProofs :=
   let obligation := fresh in
@@ -425,7 +428,8 @@ Ltac field_reflection_no_check Lem F VarMap Lpe RE1 RE2 PE1 PE2 LpeProofs :=
   [ | exact_no_check (Lem
         F 100%N VarMap Lpe RE1 RE2 PE1 PE2 LpeProofs
         ltac:(reflexivity_no_check)
-        ltac:(field_normalization; exact obligation)) ].
+        ltac:(field_normalization; exact obligation)) ];
+  field_postprocessing.
 
 Ltac field_reflection := field_reflection_check.
 


### PR DESCRIPTION
Fix #110 

This doesn't work with no_check but no_check doesn't lake much sense in this context anway, as it's essentially meant to be used wrapped in abstract, hence for goal-terminating tactics.